### PR TITLE
フッターを画面下部に固定するFlexboxレイアウトの実装

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,18 +14,28 @@ function App() {
   return (
     <MantineProvider withGlobalStyles withNormalizeCSS>
       <Router>
-        <Header />
-        <SubHeader /> {/* ここで灰色帯にページ名を表示 */}
-        <main style={{ minHeight: "70vh", padding: "1rem" }}> {/* メインコンテンツの高さを最低70vhにする */}
-          <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "0 1rem" }}> {/* コンテンツを左右の中央に揃える */}
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/profile-cv" element={<ProfileCV />} />
-              <Route path="/publications" element={<Publications />} />
-            </Routes>
-          </div>
-        </main>
-        <Footer />
+        {/* Flexboxを使用して、ページ全体を縦方向に配置 */}
+        <div style={{
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "100vh" /* ページの高さを最低でもビューポートの高さに設定 */
+        }}>
+          <Header />
+          <SubHeader /> {/* ここで灰色帯にページ名を表示 */}
+          <main style={{
+            flex: "1", /* 利用可能なスペースをすべて使用 */
+            padding: "1rem"
+          }}>
+            <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "0 1rem" }}> {/* コンテンツを左右の中央に揃える */}
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/profile-cv" element={<ProfileCV />} />
+                <Route path="/publications" element={<Publications />} />
+              </Routes>
+            </div>
+          </main>
+          <Footer />
+        </div>
       </Router>
     </MantineProvider>
   );

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -7,4 +7,7 @@
   font-size: 0.75rem;
   padding-top: 0.7rem;
   padding-bottom: 0.05rem;
+  /* フッターを下部に固定するための追加スタイル */
+  margin-top: auto; /* 上部の余白を自動調整して下部に押し出す */
+  width: 100%; /* 幅を100%に設定 */
 }


### PR DESCRIPTION
## 変更内容

Flexboxを使用してページレイアウトを調整し、フッターが常に画面の一番下に表示されるようにしました。

### 変更したファイル
- `src/App.jsx`: ページ全体をFlexboxレイアウトに変更
- `src/components/Footer.css`: フッターのスタイルを調整

## 変更理由

現在の実装では、ページコンテンツが少ない場合にフッターが画面の中央付近に表示されてしまい、ユーザーエクスペリエンスが最適ではありませんでした。この変更により、コンテンツの量に関わらず、フッターが常に画面の一番下に表示されるようになります。

## 実装詳細

### App.jsxの変更
- ページ全体を`<div>`で囲み、Flexboxレイアウトを適用
- `display: flex`と`flex-direction: column`で縦方向のFlexboxレイアウトを設定
- `minHeight: 100vh`でページの高さを最低でもビューポートの高さに設定
- メインコンテンツ部分に`flex: 1`を設定して、利用可能なスペースを埋めるように調整

### Footer.cssの変更
- `margin-top: auto`を追加して、上部の余白を自動調整し、フッターを下部に押し出すように設定
- `width: 100%`を追加して、フッターの幅を100%に設定

## テスト結果

複数のブラウザで異なる表示倍率でテストを行い、以下を確認しました：
- コンテンツが少ない場合でも、フッターは画面の一番下に表示される
- コンテンツが多い場合は、通常通りコンテンツの後にフッターが表示される
- レスポンシブデザインが正常に機能し、異なる画面サイズでも適切に表示される