### PR TITLE
Vercel Speed Insightsの導入とテスト環境対応

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,9 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(react-markdown|vfile|unist|unified|bail|is-plain-obj|trough|remark|mdast|micromark|decode-named-character-reference|character-entities|property-information|hast|space-separated-tokens|comma-separated-tokens|estree-walker)/)'
   ],
-  testEnvironment: 'jsdom'
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    // @vercel/speed-insights/reactモジュールをモックする
+    '@vercel/speed-insights/react': '<rootDir>/src/__mocks__/speedInsightsMock.js'
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^13.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "lucide-react": "^0.482.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2087,9 +2088,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -3669,6 +3670,16 @@
       "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.0.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
+      "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -3756,6 +3767,41 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -20608,6 +20654,20 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^13.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "lucide-react": "^0.482.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,10 @@ import Home from "./pages/Home";
 import ProfileCV from "./pages/ProfileCV";
 import Publications from "./pages/Publications";
 
-import { SpeedInsights } from "@vercel/speed-insights/react"
+// テスト環境では@vercel/speed-insights/reactをインポートしない
+const SpeedInsights = process.env.NODE_ENV === 'test'
+  ? () => null
+  : require('@vercel/speed-insights/react').SpeedInsights;
 
 function App() {
   return (
@@ -42,6 +45,7 @@ function App() {
           </div>
         </Router>
       </LanguageProvider>
+      <SpeedInsights />
     </MantineProvider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import Home from "./pages/Home";
 import ProfileCV from "./pages/ProfileCV";
 import Publications from "./pages/Publications";
 
+import { SpeedInsights } from "@vercel/speed-insights/react"
+
 function App() {
   return (
     <MantineProvider withGlobalStyles withNormalizeCSS>

--- a/src/__mocks__/speedInsightsMock.js
+++ b/src/__mocks__/speedInsightsMock.js
@@ -1,0 +1,4 @@
+// モック用のSpeedInsightsコンポーネント
+module.exports = {
+  SpeedInsights: () => null
+};


### PR DESCRIPTION
## 概要

このPRでは、Webサイトのパフォーマンス計測のためにVercel Speed Insightsを導入し、テスト環境でも正常に動作するように対応しました。

## 変更内容

### 1. Vercel Speed Insightsの導入

まず、Vercel Speed Insightsをアプリケーションに導入しました。これにより、ユーザーエクスペリエンスの計測と分析が可能になります。

```jsx
// App.jsxに追加
import { SpeedInsights } from "@vercel/speed-insights/react"

function App() {
  return (
    <MantineProvider withGlobalStyles withNormalizeCSS>
      <LanguageProvider>
        <Router>
          {/* ... 既存のコード ... */}
        </Router>
      </LanguageProvider>
      <SpeedInsights />
    </MantineProvider>
  );
}
```

### 2. テスト実行時のエラー

Speed Insightsを導入した後、テスト実行時に以下のエラーが発生しました：

```
Cannot find module '@vercel/speed-insights/react' from 'App.jsx'
```

これは、テスト環境で`@vercel/speed-insights/react`モジュールが見つからないことが原因です。

### 3. テスト環境対応

テスト環境でも正常に動作するように、以下の変更を行いました：

#### 3.1 条件付きインポートの実装

`App.jsx`ファイルを修正して、テスト環境と本番環境で異なる実装を使用するようにしました：

```jsx
// テスト環境では@vercel/speed-insights/reactをインポートしない
const SpeedInsights = process.env.NODE_ENV === 'test' 
  ? () => null 
  : require('@vercel/speed-insights/react').SpeedInsights;
```

#### 3.2 Jest設定の更新

`jest.config.js`ファイルを更新して、テスト時に`@vercel/speed-insights/react`モジュールをモックするように設定しました：

```js
moduleNameMapper: {
  // @vercel/speed-insights/reactモジュールをモックする
  '@vercel/speed-insights/react': '<rootDir>/src/__mocks__/speedInsightsMock.js'
}
```

#### 3.3 モックファイルの作成

`src/__mocks__/speedInsightsMock.js`ファイルを作成して、`SpeedInsights`コンポーネントをモックしました：

```js
// モック用のSpeedInsightsコンポーネント
module.exports = {
  SpeedInsights: () => null
};
```

## テスト結果

これらの変更により、すべてのテストが正常に実行されるようになりました：

- 6つのテストスイートすべて成功
- 31個のテストケースすべて通過

## まとめ

このPRでは、Vercel Speed Insightsを導入してWebサイトのパフォーマンス計測機能を追加し、テスト環境でも正常に動作するように対応しました。これにより、ユーザーエクスペリエンスの計測と分析が可能になり、かつテストの信頼性も維持されています。