### PR TITLE
出版物表示の改善

### DIFF
--- a/docs/publication_display.md
+++ b/docs/publication_display.md
@@ -1,0 +1,151 @@
+# 出版物データの表示プロセス
+
+このドキュメントでは、CSVファイルの出版物データがウェブサイト上でどのように処理され表示されるかについて説明します。
+
+## データフロー概要
+
+出版物データは以下のプロセスを経て、ウェブサイト上に表示されます：
+
+1. CSVファイル（`data/publication_data.csv`）に出版物データを記録
+2. 変換スクリプト（`scripts/convertPublications.js`）を実行してJSONファイルに変換
+3. 変換されたJSONデータ（`src/data/publications.json`）をReactコンポーネントで読み込み
+4. Publicationsコンポーネント（`src/pages/Publications.jsx`）でデータを整形して表示
+
+## CSVファイルの構造
+
+出版物データのCSVファイルは以下の列を含みます：
+
+| 列番号 | 列名 | 説明 |
+|-------|------|------|
+| 1 | 未入力項目有り | 空の項目があるかどうか（Yes/No） |
+| 2 | 名前 | 著者名と論文タイトル（英語） |
+| 3 | Japanese（日本語） | 著者名と論文タイトル（日本語） |
+| 4 | type | 論文の種類（Research paper, Journal paperなど） |
+| 5 | Review | 査読の有無（Reviewed, Not reviewedなど） |
+| 6 | Authorship | 著者の役割（Lead author, Co-authorなど） |
+| 7 | Presentation type | 発表の種類（Oral, Posterなど） |
+| 8 | DOI | Digital Object Identifier |
+| 9 | web link | ウェブリンク |
+| 10 | Date | 発表日 |
+| 11 | Others | その他の情報 |
+| 12 | site | 開催場所 |
+| 13 | journal / conference | ジャーナル名または会議名 |
+
+### CSVフォーマットの注意点
+
+- 1行目はヘッダー行として扱われます
+- 空行は無視されます
+- 引用符（"）で囲まれた値内のカンマは、区切り文字ではなく値の一部として扱われます
+- 名前フィールドと日本語フィールドは、「著者名, "タイトル"」の形式で記述されます
+  - 例: `Rio Tomioka and Masanori Takabayashi, "Numerical simulations of neural network hardware based on self-referential holography"`
+
+## CSVからJSONへの変換
+
+`csvToJson.js`ユーティリティは、CSVファイルを読み込み、以下の処理を行います：
+
+1. CSVファイルを行ごとに分割
+2. 各行をCSV形式として正しく解析（引用符内のカンマを考慮）
+3. 各フィールドをトリムし、適切なプロパティ名でマッピング
+4. 空行や不正な形式の行をスキップ
+
+変換されたJSONデータの例：
+
+```json
+{
+  "hasEmptyFields": false,
+  "name": "Rio Tomioka and Masanori Takabayashi, \"Numerical simulations of neural network hardware based on self-referential holography\"",
+  "japanese": "冨岡莉生, 高林正典, \"自己参照型ホログラフィを用いたニューラルネットワークハードウェアの数値シミュレーション\"",
+  "type": "Research paper (international conference)",
+  "review": "Reviewed",
+  "authorship": "Lead author",
+  "presentationType": "Oral",
+  "doi": "",
+  "webLink": "https://example.com/paper1",
+  "date": "2021年10月3日 → 2021年10月6日",
+  "others": "",
+  "site": "online",
+  "journalConference": "ISOM21"
+}
+```
+
+## Publicationsページでの表示
+
+Publicationsコンポーネント（`src/pages/Publications.jsx`）は、JSONデータを読み込み、以下の処理を行います：
+
+### データの整形
+
+1. 名前フィールドから著者とタイトルを分離
+   ```javascript
+   const nameParts = pub.name.split(', "');
+   const authors = nameParts[0];
+   const title = nameParts.length > 1 ? nameParts[1].replace(/"/g, '') : pub.name;
+   ```
+
+2. 日本語フィールドからも同様に著者とタイトルを分離
+   ```javascript
+   const jaNameParts = pub.japanese.split(', "');
+   japaneseAuthors = jaNameParts[0];
+   japaneseTitle = jaNameParts.length > 1 ? jaNameParts[1].replace(/"/g, '') : pub.japanese;
+   ```
+
+3. 日付から年を抽出
+   ```javascript
+   const match = dateString.match(/(\d{4})/);
+   return match ? parseInt(match[1], 10) : null;
+   ```
+
+### 表示機能
+
+1. **年度フィルタリング**
+   - ユニークな年度を抽出し、ドロップダウンリストとして表示
+   - 選択された年度に基づいて出版物をフィルタリング
+
+2. **言語切替**
+   - 言語設定（ja/en）に応じて、適切な言語でタイトルと著者名を表示
+   - 日本語モードでは日本語のタイトルと著者名、英語モードでは英語のタイトルと著者名を表示
+
+3. **出版物リスト表示**
+   - 各出版物は以下の形式で表示されます：
+     - タイトル（太字）と年
+     - 著者名（イタリック体）とジャーナル/会議名
+     - ウェブリンク（存在する場合）
+
+### 表示例
+
+英語モードでの表示：
+```
+Numerical simulations of neural network hardware based on self-referential holography (2021)
+Rio Tomioka and Masanori Takabayashi - ISOM21 [Link]
+```
+
+日本語モードでの表示：
+```
+自己参照型ホログラフィを用いたニューラルネットワークハードウェアの数値シミュレーション (2021)
+冨岡莉生, 高林正典 - ISOM21 [Link]
+```
+
+## テスト
+
+システムには以下のテストが実装されています：
+
+1. **csvToJson.test.js**
+   - 変換関数の存在確認
+   - CSVファイルの存在確認
+   - CSVからJSONへの正確な変換
+   - 空行や不正な形式の行の適切な処理
+
+2. **Publications.test.jsx**
+   - 出版物リストの正常表示
+   - 年度フィルターの機能
+   - 言語切替（日本語/英語）の機能
+
+## データ更新手順
+
+出版物データを更新する場合は、以下の手順に従います：
+
+1. `data/publication_data.csv`ファイルを編集または置き換え
+2. 変換スクリプトを実行：
+   ```bash
+   node scripts/convertPublications.js
+   ```
+3. 変換が完了すると、`src/data/publications.json`が更新され、ウェブサイト上に反映されます

--- a/docs/publication_display.md
+++ b/docs/publication_display.md
@@ -74,54 +74,60 @@ Publicationsコンポーネント（`src/pages/Publications.jsx`）は、JSONデ
 
 ### データの整形
 
-1. 名前フィールドから著者とタイトルを分離
-   ```javascript
-   const nameParts = pub.name.split(', "');
-   const authors = nameParts[0];
-   const title = nameParts.length > 1 ? nameParts[1].replace(/"/g, '') : pub.name;
-   ```
-
-2. 日本語フィールドからも同様に著者とタイトルを分離
-   ```javascript
-   const jaNameParts = pub.japanese.split(', "');
-   japaneseAuthors = jaNameParts[0];
-   japaneseTitle = jaNameParts.length > 1 ? jaNameParts[1].replace(/"/g, '') : pub.japanese;
-   ```
-
-3. 日付から年を抽出
+1. 日付から年を抽出
    ```javascript
    const match = dateString.match(/(\d{4})/);
    return match ? parseInt(match[1], 10) : null;
    ```
 
+2. 出版物データを新しい順に並べ替え
+   ```javascript
+   .sort((a, b) => {
+     // 新しい順に並べる（年が新しい順）
+     return (b.year || 0) - (a.year || 0);
+   });
+   ```
+
 ### 表示機能
 
-1. **年度フィルタリング**
-   - ユニークな年度を抽出し、ドロップダウンリストとして表示
-   - 選択された年度に基づいて出版物をフィルタリング
+1. **複数のフィルタリング機能**
+   - **年度フィルター**: 出版年でフィルタリング
+   - **著者の役割フィルター**: Lead author、Co-authorなどでフィルタリング
+   - **種類フィルター**: Research paper、Journal paperなどでフィルタリング
+   - **レビューフィルター**: Reviewed、Not reviewedなどでフィルタリング
+   - **発表タイプフィルター**: Oral、Posterなどでフィルタリング
+   - 複数のフィルターを組み合わせて使用可能
+   - フィルターのリセット機能
 
 2. **言語切替**
-   - 言語設定（ja/en）に応じて、適切な言語でタイトルと著者名を表示
-   - 日本語モードでは日本語のタイトルと著者名、英語モードでは英語のタイトルと著者名を表示
+   - 言語設定（ja/en）に応じて、適切な言語でタイトルを表示
+   - 日本語モードでは日本語のタイトル、英語モードでは英語のタイトルを表示
 
 3. **出版物リスト表示**
    - 各出版物は以下の形式で表示されます：
-     - タイトル（太字）と年
-     - 著者名（イタリック体）とジャーナル/会議名
+     - タイトル（太字）
+     - タグ（年、著者の役割、種類、レビュー、発表タイプ）
+     - ジャーナル/会議名
+     - DOI（存在する場合）
      - ウェブリンク（存在する場合）
+     - その他の情報（存在する場合）
 
 ### 表示例
 
 英語モードでの表示：
 ```
-Numerical simulations of neural network hardware based on self-referential holography (2021)
-Rio Tomioka and Masanori Takabayashi - ISOM21 [Link]
+Numerical simulations of neural network hardware based on self-referential holography
+[2021] [Lead author] [Research paper (international conference)] [Reviewed] [Oral]
+ISOM21
+https://example.com/paper1
 ```
 
 日本語モードでの表示：
 ```
-自己参照型ホログラフィを用いたニューラルネットワークハードウェアの数値シミュレーション (2021)
-冨岡莉生, 高林正典 - ISOM21 [Link]
+自己参照型ホログラフィを用いたニューラルネットワークハードウェアの数値シミュレーション
+[2021] [Lead author] [Research paper (international conference)] [Reviewed] [Oral]
+ISOM21
+https://example.com/paper1
 ```
 
 ## テスト
@@ -136,7 +142,9 @@ Rio Tomioka and Masanori Takabayashi - ISOM21 [Link]
 
 2. **Publications.test.jsx**
    - 出版物リストの正常表示
-   - 年度フィルターの機能
+   - 複数のフィルター機能のテスト（年度、著者の役割、種類、レビュー、発表タイプ）
+   - アクティブなフィルターの表示スタイル確認
+   - フィルターリセット機能のテスト
    - 言語切替（日本語/英語）の機能
 
 ## データ更新手順

--- a/scripts/convertPublications.js
+++ b/scripts/convertPublications.js
@@ -4,7 +4,7 @@
  * 使用方法:
  * node scripts/convertPublications.js
  *
- * 入力: data/publication_proper_data.csv
+ * 入力: data/publication_data.csv
  * 出力: src/data/publications.json
  */
 

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -83,9 +83,10 @@ describe('Publications Component', () => {
     // 注: 著者とタイトルの分離に依存せず、出版物データの一部が表示されていることを確認
     expect(firstItem.textContent).toContain('ISOM21');
     
-    // タグ（Authorship、type、Review、Presentation）が表示されていることを確認
+    // タグ（Year、Authorship、type、Review、Presentation）が表示されていることを確認
     const tags = firstItem.querySelectorAll('.tag');
     expect(tags.length).toBeGreaterThan(0);
+    expect(firstItem.textContent).toContain('2021');
     expect(firstItem.textContent).toContain('Lead author');
     expect(firstItem.textContent).toContain('Research paper');
     expect(firstItem.textContent).toContain('Reviewed');
@@ -106,6 +107,52 @@ describe('Publications Component', () => {
     const link = firstItem.querySelector('a');
     expect(link).not.toBeNull();
     expect(link.getAttribute('href')).toBe('https://example.com/paper1');
+  });
+  
+  test('should filter publications by tag', () => {
+    // テスト内容: タグによるフィルタリングが正しく機能することを確認
+    renderWithLanguageProvider(<Publications />);
+    
+    // 初期状態では全ての出版物が表示されていることを確認
+    const initialItems = screen.getAllByRole('listitem');
+    expect(initialItems.length).toBe(2);
+    
+    // タグをクリックしてフィルタリング
+    const leadAuthorTag = screen.getAllByText('Lead author')[0];
+    fireEvent.click(leadAuthorTag);
+    
+    // Lead authorタグでフィルタリングされた出版物が表示されていることを確認
+    const filteredItems = screen.getAllByRole('listitem');
+    expect(filteredItems.length).toBe(2); // 両方ともLead author
+    
+    // 別のタグでフィルタリング
+    const reviewedTag = screen.getByText('Reviewed');
+    fireEvent.click(reviewedTag);
+    
+    // Reviewedタグでフィルタリングされた出版物が表示されていることを確認
+    const reviewedItems = screen.getAllByRole('listitem');
+    expect(reviewedItems.length).toBe(1);
+    expect(reviewedItems[0].textContent).toContain('Reviewed');
+    expect(reviewedItems[0].textContent).not.toContain('Not reviewed');
+    
+    // 年のタグでフィルタリング（タグの中の2021を選択）
+    const yearTags = screen.getAllByText('2021');
+    // タグは2番目の要素（最初はオプション要素）
+    fireEvent.click(yearTags[1]);
+    
+    // 2021年のタグでフィルタリングされた出版物が表示されていることを確認
+    const yearItems = screen.getAllByRole('listitem');
+    expect(yearItems.length).toBe(1);
+    expect(yearItems[0].textContent).toContain('2021');
+    expect(yearItems[0].textContent).not.toContain('2022');
+    
+    // フィルターをリセット（言語設定に応じたテキストを使用）
+    const resetButton = screen.getByText('フィルターをリセット');
+    fireEvent.click(resetButton);
+    
+    // リセット後は全ての出版物が表示されていることを確認
+    const resetItems = screen.getAllByRole('listitem');
+    expect(resetItems.length).toBe(2);
   });
   
   test('should filter publications by year', () => {
@@ -150,6 +197,7 @@ describe('Publications Component', () => {
     // タグが表示されていることを確認
     const tags2022 = items2022[0].querySelectorAll('.tag');
     expect(tags2022.length).toBeGreaterThan(0);
+    expect(items2022[0].textContent).toContain('2022');
     expect(items2022[0].textContent).toContain('Not reviewed');
     
     // URLリンクが二行目以降に表示されていることを確認
@@ -179,6 +227,9 @@ describe('Publications Component', () => {
     
     // 日本語の内容が表示されていることを確認
     expect(firstItem.textContent).toContain('自己参照型');
+    
+    // 年のタグが表示されていることを確認
+    expect(firstItem.textContent).toContain('2021');
     expect(firstItem.textContent).toContain('冨岡');
     
     // 一行目に年が表示されていないことを確認

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -75,17 +75,14 @@ describe('Publications Component', () => {
     // コンソールに出力して確認
     console.log('Publication Items:', publicationItems.map(item => item.textContent));
     
-    // テスト内容: タイトルと著者名が正しく表示されることを確認
+    // テスト内容: 出版物の内容が正しく表示されることを確認
     const firstItem = publicationItems[0];
     expect(firstItem.textContent).not.toBe(' () - ');
     
-    // 論文タイトルが表示されていることを確認（複数ある場合はgetAllByTextを使用）
-    const titleElements = screen.getAllByText(/Numerical simulations of neural network hardware/i);
-    expect(titleElements.length).toBeGreaterThan(0);
-    
-    // 著者名が表示されていることを確認（複数ある場合はgetAllByTextを使用）
-    const authorElements = screen.getAllByText(/Rio Tomioka/i);
-    expect(authorElements.length).toBeGreaterThan(0);
+    // 出版物の内容が表示されていることを確認
+    // 注: 著者とタイトルの分離に依存せず、出版物データの一部が表示されていることを確認
+    expect(firstItem.textContent).toContain('2021');
+    expect(firstItem.textContent).toContain('ISOM21');
   });
   
   test('should filter publications by year', () => {
@@ -111,15 +108,21 @@ describe('Publications Component', () => {
     fireEvent.change(yearSelect, { target: { value: '2021' } });
     
     // 2021年の出版物のみが表示されていることを確認
-    expect(screen.getByText(/Numerical simulations of neural network hardware/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Improvement of learning process/i)).not.toBeInTheDocument();
+    const items2021 = screen.getAllByRole('listitem');
+    expect(items2021.length).toBe(1);
+    expect(items2021[0].textContent).toContain('2021');
+    expect(items2021[0].textContent).toContain('ISOM21');
+    expect(items2021[0].textContent).not.toContain('MMS2022');
     
     // 2022年に変更
     fireEvent.change(yearSelect, { target: { value: '2022' } });
     
     // 2022年の出版物のみが表示されていることを確認
-    expect(screen.queryByText(/Numerical simulations of neural network hardware/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Improvement of learning process/i)).toBeInTheDocument();
+    const items2022 = screen.getAllByRole('listitem');
+    expect(items2022.length).toBe(1);
+    expect(items2022[0].textContent).toContain('2022');
+    expect(items2022[0].textContent).toContain('MMS2022');
+    expect(items2022[0].textContent).not.toContain('ISOM21');
   });
   
   test('should display publications in Japanese when language is set to Japanese', () => {
@@ -134,13 +137,16 @@ describe('Publications Component', () => {
     const publicationItems = screen.getAllByRole('listitem');
     console.log('Japanese publication items:', publicationItems.map(item => item.textContent));
     
-    // テスト内容: 日本語のタイトルと著者名が正しく表示されることを確認
+    // テスト内容: 日本語の内容が表示されることを確認
     
-    // 日本語のタイトルが表示されていることを確認
-    expect(screen.getByText(/自己参照型ホログラフィを用いたニューラルネットワークハードウェアの数値シミュレーション/i)).toBeInTheDocument();
+    // 日本語の内容が含まれていることを確認
+    // 注: 著者とタイトルの分離に依存せず、日本語の内容が表示されていることを確認
+    const firstItem = publicationItems[0];
+    expect(firstItem.textContent).toContain('2021');
+    expect(firstItem.textContent).toContain('ISOM21');
     
-    // 日本語の著者名が表示されていることを確認（複数ある場合はgetAllByTextを使用）
-    const authorElements = screen.getAllByText(/冨岡莉生/i);
-    expect(authorElements.length).toBeGreaterThan(0);
+    // 日本語の内容が表示されていることを確認
+    expect(firstItem.textContent).toContain('自己参照型');
+    expect(firstItem.textContent).toContain('冨岡');
   });
 });

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -67,7 +67,7 @@ describe('Publications Component', () => {
     renderWithLanguageProvider(<Publications />);
     
     // 現在のコンポーネントが新しいJSONデータ構造でどのように動作しているかを確認
-    const publicationItems = screen.getAllByRole('listitem');
+    const publicationItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     
     // 少なくとも1つの出版物アイテムが表示されていることを確認
     expect(publicationItems.length).toBeGreaterThan(0);
@@ -81,15 +81,20 @@ describe('Publications Component', () => {
     
     // 出版物の内容が表示されていることを確認
     // 注: 著者とタイトルの分離に依存せず、出版物データの一部が表示されていることを確認
-    expect(firstItem.textContent).toContain('ISOM21');
+    // 新しい順に並んでいるため、最初の項目は2022年のものになる
+    expect(firstItem.textContent).toContain('MMS2022');
+    
+    // リストが数字の箇条書きになっていることを確認
+    const orderedList = screen.getByRole('list');
+    expect(orderedList.tagName).toBe('OL');
     
     // タグ（Year、Authorship、type、Review、Presentation）が表示されていることを確認
     const tags = firstItem.querySelectorAll('.tag');
     expect(tags.length).toBeGreaterThan(0);
-    expect(firstItem.textContent).toContain('2021');
+    expect(firstItem.textContent).toContain('2022');
     expect(firstItem.textContent).toContain('Lead author');
     expect(firstItem.textContent).toContain('Research paper');
-    expect(firstItem.textContent).toContain('Reviewed');
+    expect(firstItem.textContent).toContain('Not reviewed');
     expect(firstItem.textContent).toContain('Oral');
     
     // 一行目に年が表示されていないことを確認
@@ -101,12 +106,12 @@ describe('Publications Component', () => {
     expect(secondLine).not.toBeNull();
     
     // ジャーナル名が三行目に表示されていることを確認
-    expect(firstItem.textContent).toContain('ISOM21');
+    expect(firstItem.textContent).toContain('MMS2022');
     
     // URLリンクが表示されていることを確認
     const link = firstItem.querySelector('a');
     expect(link).not.toBeNull();
-    expect(link.getAttribute('href')).toBe('https://example.com/paper1');
+    expect(link.getAttribute('href')).toBe('https://example.com/paper2');
   });
   
   test('should filter publications using dropdown filters', () => {
@@ -114,7 +119,7 @@ describe('Publications Component', () => {
     renderWithLanguageProvider(<Publications />);
     
     // 初期状態では全ての出版物が表示されていることを確認
-    const initialItems = screen.getAllByRole('listitem');
+    const initialItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     expect(initialItems.length).toBe(2);
     
     // 年のフィルターボタンをクリック
@@ -130,7 +135,7 @@ describe('Publications Component', () => {
     fireEvent.click(year2021Checkbox);
     
     // 2021年でフィルタリングされた出版物が表示されていることを確認
-    const yearFilteredItems = screen.getAllByRole('listitem');
+    const yearFilteredItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     expect(yearFilteredItems.length).toBe(1);
     expect(yearFilteredItems[0].textContent).toContain('2021');
     expect(yearFilteredItems[0].textContent).not.toContain('2022');
@@ -149,7 +154,7 @@ describe('Publications Component', () => {
     
     // Lead authorでフィルタリングされた出版物が表示されていることを確認
     // 2021年のフィルターと組み合わせて、両方の条件に一致する出版物のみが表示される
-    const combinedFilteredItems = screen.getAllByRole('listitem');
+    const combinedFilteredItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     expect(combinedFilteredItems.length).toBe(1);
     expect(combinedFilteredItems[0].textContent).toContain('2021');
     expect(combinedFilteredItems[0].textContent).toContain('Lead author');
@@ -159,7 +164,7 @@ describe('Publications Component', () => {
     fireEvent.click(resetButton);
     
     // リセット後は全ての出版物が表示されていることを確認
-    const resetItems = screen.getAllByRole('listitem');
+    const resetItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     expect(resetItems.length).toBe(2);
   });
   
@@ -212,7 +217,7 @@ describe('Publications Component', () => {
     expect(yearFilterButton).toBeInTheDocument();
     
     // 出版物リストを確認
-    const publicationItems = screen.getAllByRole('listitem');
+    const publicationItems = screen.getAllByRole('listitem', { within: screen.getByRole('list') });
     console.log('Japanese publication items:', publicationItems.map(item => item.textContent));
     
     // テスト内容: 日本語の内容が表示されることを確認
@@ -220,18 +225,21 @@ describe('Publications Component', () => {
     // 日本語の内容が含まれていることを確認
     // 注: 著者とタイトルの分離に依存せず、日本語の内容が表示されていることを確認
     const firstItem = publicationItems[0];
-    expect(firstItem.textContent).toContain('ISOM21');
+    
+    // 新しい順に並んでいることを確認（最初の項目が2022年のものであることを確認）
+    expect(firstItem.textContent).toContain('2022');
+    expect(firstItem.textContent).toContain('MMS2022');
     
     // 日本語の内容が表示されていることを確認
-    expect(firstItem.textContent).toContain('自己参照型');
+    expect(firstItem.textContent).toContain('透過行列');
     
     // 年のタグが表示されていることを確認
-    expect(firstItem.textContent).toContain('2021');
+    expect(firstItem.textContent).toContain('2022');
     expect(firstItem.textContent).toContain('冨岡');
     
     // 一行目に年が表示されていないことを確認
     const firstLine = firstItem.querySelector('strong').textContent;
-    expect(firstLine).not.toContain('2021');
+    expect(firstLine).not.toContain('2022');
     
     // タグが二行目に表示されていることを確認
     const secondLine = firstItem.querySelector('.tags-container');

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -109,44 +109,52 @@ describe('Publications Component', () => {
     expect(link.getAttribute('href')).toBe('https://example.com/paper1');
   });
   
-  test('should filter publications by tag', () => {
-    // テスト内容: タグによるフィルタリングが正しく機能することを確認
+  test('should filter publications using dropdown filters', () => {
+    // テスト内容: ドロップダウンフィルターが正しく機能することを確認
     renderWithLanguageProvider(<Publications />);
     
     // 初期状態では全ての出版物が表示されていることを確認
     const initialItems = screen.getAllByRole('listitem');
     expect(initialItems.length).toBe(2);
     
-    // タグをクリックしてフィルタリング
-    const leadAuthorTag = screen.getAllByText('Lead author')[0];
-    fireEvent.click(leadAuthorTag);
+    // 年のフィルターボタンをクリック
+    const yearFilterButton = screen.getByText('年度 ▼');
+    fireEvent.click(yearFilterButton);
     
-    // Lead authorタグでフィルタリングされた出版物が表示されていることを確認
-    const filteredItems = screen.getAllByRole('listitem');
-    expect(filteredItems.length).toBe(2); // 両方ともLead author
+    // ドロップダウンメニューが表示されることを確認
+    const yearDropdown = screen.getByTestId('year-dropdown');
+    expect(yearDropdown).toBeInTheDocument();
     
-    // 別のタグでフィルタリング
-    const reviewedTag = screen.getByText('Reviewed');
-    fireEvent.click(reviewedTag);
+    // 2021年のチェックボックスをクリック
+    const year2021Checkbox = screen.getByLabelText('2021');
+    fireEvent.click(year2021Checkbox);
     
-    // Reviewedタグでフィルタリングされた出版物が表示されていることを確認
-    const reviewedItems = screen.getAllByRole('listitem');
-    expect(reviewedItems.length).toBe(1);
-    expect(reviewedItems[0].textContent).toContain('Reviewed');
-    expect(reviewedItems[0].textContent).not.toContain('Not reviewed');
+    // 2021年でフィルタリングされた出版物が表示されていることを確認
+    const yearFilteredItems = screen.getAllByRole('listitem');
+    expect(yearFilteredItems.length).toBe(1);
+    expect(yearFilteredItems[0].textContent).toContain('2021');
+    expect(yearFilteredItems[0].textContent).not.toContain('2022');
     
-    // 年のタグでフィルタリング（タグの中の2021を選択）
-    const yearTags = screen.getAllByText('2021');
-    // タグは2番目の要素（最初はオプション要素）
-    fireEvent.click(yearTags[1]);
+    // 著者の役割のフィルターボタンをクリック
+    const authorshipFilterButton = screen.getByText('著者の役割 ▼');
+    fireEvent.click(authorshipFilterButton);
     
-    // 2021年のタグでフィルタリングされた出版物が表示されていることを確認
-    const yearItems = screen.getAllByRole('listitem');
-    expect(yearItems.length).toBe(1);
-    expect(yearItems[0].textContent).toContain('2021');
-    expect(yearItems[0].textContent).not.toContain('2022');
+    // ドロップダウンメニューが表示されることを確認
+    const authorshipDropdown = screen.getByTestId('authorship-dropdown');
+    expect(authorshipDropdown).toBeInTheDocument();
     
-    // フィルターをリセット（言語設定に応じたテキストを使用）
+    // Lead authorのチェックボックスをクリック
+    const leadAuthorCheckbox = screen.getByLabelText('Lead author');
+    fireEvent.click(leadAuthorCheckbox);
+    
+    // Lead authorでフィルタリングされた出版物が表示されていることを確認
+    // 2021年のフィルターと組み合わせて、両方の条件に一致する出版物のみが表示される
+    const combinedFilteredItems = screen.getAllByRole('listitem');
+    expect(combinedFilteredItems.length).toBe(1);
+    expect(combinedFilteredItems[0].textContent).toContain('2021');
+    expect(combinedFilteredItems[0].textContent).toContain('Lead author');
+    
+    // フィルターをリセット
     const resetButton = screen.getByText('フィルターをリセット');
     fireEvent.click(resetButton);
     
@@ -155,64 +163,53 @@ describe('Publications Component', () => {
     expect(resetItems.length).toBe(2);
   });
   
-  test('should filter publications by year', () => {
-    // テスト内容: 年度フィルターが正しく機能することを確認
+  test('should show active filters with different color', () => {
+    // テスト内容: アクティブなフィルターが異なる色で表示されることを確認
     renderWithLanguageProvider(<Publications />);
     
-    // 年度フィルターを取得（言語に依存しない方法で）
-    const yearSelect = screen.getByRole('combobox');
+    // 年のフィルターボタンをクリック
+    const yearFilterButton = screen.getByText('年度 ▼');
+    fireEvent.click(yearFilterButton);
     
-    // 現在選択されている年度を確認
-    console.log('Current selected year:', yearSelect.value);
+    // 2021年のチェックボックスをクリック
+    const year2021Checkbox = screen.getByLabelText('2021');
+    fireEvent.click(year2021Checkbox);
     
-    // 利用可能な年度オプションを確認
-    const yearOptions = Array.from(yearSelect.options).map(option => option.value);
-    console.log('Available year options:', yearOptions);
+    // フィルターボタンの色が変わっていることを確認
+    const activeYearFilter = screen.getByText('年度 ▼');
+    expect(activeYearFilter).toHaveAttribute('style', expect.stringContaining('background-color: rgb(192, 224, 255)'));
     
-    // テスト内容: 年度オプションが正しく抽出されることを確認
-    expect(yearOptions).toContain('2021');
-    expect(yearOptions).toContain('2022');
+    // 著者の役割のフィルターボタンをクリック
+    const authorshipFilterButton = screen.getByText('著者の役割 ▼');
+    fireEvent.click(authorshipFilterButton);
     
-    // 年度フィルターが機能するか確認
-    // 2021年を選択
-    fireEvent.change(yearSelect, { target: { value: '2021' } });
+    // Lead authorのチェックボックスをクリック
+    const leadAuthorCheckbox = screen.getByLabelText('Lead author');
+    fireEvent.click(leadAuthorCheckbox);
     
-    // 2021年の出版物のみが表示されていることを確認
-    const items2021 = screen.getAllByRole('listitem');
-    expect(items2021.length).toBe(1);
-    expect(items2021[0].textContent).toContain('ISOM21');
-    expect(items2021[0].textContent).not.toContain('MMS2022');
+    // フィルターボタンの色が変わっていることを確認
+    const activeAuthorshipFilter = screen.getByText('著者の役割 ▼');
+    expect(activeAuthorshipFilter).toHaveAttribute('style', expect.stringContaining('background-color: rgb(192, 224, 255)'));
     
-    // 年度は内部的に保持されていることを確認（フィルタリングが機能している）
+    // フィルターをリセット
+    const resetButton = screen.getByText('フィルターをリセット');
+    fireEvent.click(resetButton);
     
-    // 2022年に変更
-    fireEvent.change(yearSelect, { target: { value: '2022' } });
+    // フィルターボタンの色が元に戻っていることを確認
+    const inactiveYearFilter = screen.getByText('年度 ▼');
+    expect(inactiveYearFilter).toHaveAttribute('style', expect.stringContaining('background-color: rgb(240, 240, 240)'));
     
-    // 2022年の出版物のみが表示されていることを確認
-    const items2022 = screen.getAllByRole('listitem');
-    expect(items2022.length).toBe(1);
-    expect(items2022[0].textContent).toContain('MMS2022');
-    expect(items2022[0].textContent).not.toContain('ISOM21');
-    
-    // タグが表示されていることを確認
-    const tags2022 = items2022[0].querySelectorAll('.tag');
-    expect(tags2022.length).toBeGreaterThan(0);
-    expect(items2022[0].textContent).toContain('2022');
-    expect(items2022[0].textContent).toContain('Not reviewed');
-    
-    // URLリンクが二行目以降に表示されていることを確認
-    const link2022 = items2022[0].querySelector('a');
-    expect(link2022).not.toBeNull();
-    expect(link2022.getAttribute('href')).toBe('https://example.com/paper2');
+    const inactiveAuthorshipFilter = screen.getByText('著者の役割 ▼');
+    expect(inactiveAuthorshipFilter).toHaveAttribute('style', expect.stringContaining('background-color: rgb(240, 240, 240)'));
   });
   
   test('should display publications in Japanese when language is set to Japanese', () => {
     // テスト内容: 言語設定が日本語の場合、出版物が日本語で表示されることを確認
     renderWithLanguageProvider(<Publications />, { language: 'ja' });
     
-    // フィルターラベルが日本語になっていることを確認
-    const filterLabel = screen.getByText(/絞り込み \(年度\)/i);
-    expect(filterLabel).toBeInTheDocument();
+    // フィルターボタンが日本語になっていることを確認
+    const yearFilterButton = screen.getByText('年度 ▼');
+    expect(yearFilterButton).toBeInTheDocument();
     
     // 出版物リストを確認
     const publicationItems = screen.getAllByRole('listitem');

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -83,11 +83,26 @@ describe('Publications Component', () => {
     // 注: 著者とタイトルの分離に依存せず、出版物データの一部が表示されていることを確認
     expect(firstItem.textContent).toContain('ISOM21');
     
+    // タグ（Authorship、type、Review、Presentation）が表示されていることを確認
+    const tags = firstItem.querySelectorAll('.tag');
+    expect(tags.length).toBeGreaterThan(0);
+    expect(firstItem.textContent).toContain('Lead author');
+    expect(firstItem.textContent).toContain('Research paper');
+    expect(firstItem.textContent).toContain('Reviewed');
+    expect(firstItem.textContent).toContain('Oral');
+    
     // 一行目に年が表示されていないことを確認
     const firstLine = firstItem.querySelector('strong').textContent;
     expect(firstLine).not.toContain('2021');
     
-    // URLリンクが二行目以降に表示されていることを確認
+    // タグが二行目に表示されていることを確認
+    const secondLine = firstItem.querySelector('.tags-container');
+    expect(secondLine).not.toBeNull();
+    
+    // ジャーナル名が三行目に表示されていることを確認
+    expect(firstItem.textContent).toContain('ISOM21');
+    
+    // URLリンクが表示されていることを確認
     const link = firstItem.querySelector('a');
     expect(link).not.toBeNull();
     expect(link.getAttribute('href')).toBe('https://example.com/paper1');
@@ -132,6 +147,11 @@ describe('Publications Component', () => {
     expect(items2022[0].textContent).toContain('MMS2022');
     expect(items2022[0].textContent).not.toContain('ISOM21');
     
+    // タグが表示されていることを確認
+    const tags2022 = items2022[0].querySelectorAll('.tag');
+    expect(tags2022.length).toBeGreaterThan(0);
+    expect(items2022[0].textContent).toContain('Not reviewed');
+    
     // URLリンクが二行目以降に表示されていることを確認
     const link2022 = items2022[0].querySelector('a');
     expect(link2022).not.toBeNull();
@@ -165,7 +185,11 @@ describe('Publications Component', () => {
     const firstLine = firstItem.querySelector('strong').textContent;
     expect(firstLine).not.toContain('2021');
     
-    // URLリンクが二行目以降に表示されていることを確認
+    // タグが二行目に表示されていることを確認
+    const secondLine = firstItem.querySelector('.tags-container');
+    expect(secondLine).not.toBeNull();
+    
+    // URLリンクが表示されていることを確認
     const link = firstItem.querySelector('a');
     expect(link).not.toBeNull();
   });

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -77,12 +77,20 @@ describe('Publications Component', () => {
     
     // テスト内容: 出版物の内容が正しく表示されることを確認
     const firstItem = publicationItems[0];
-    expect(firstItem.textContent).not.toBe(' () - ');
+    expect(firstItem.textContent).not.toBe('');
     
     // 出版物の内容が表示されていることを確認
     // 注: 著者とタイトルの分離に依存せず、出版物データの一部が表示されていることを確認
-    expect(firstItem.textContent).toContain('2021');
     expect(firstItem.textContent).toContain('ISOM21');
+    
+    // 一行目に年が表示されていないことを確認
+    const firstLine = firstItem.querySelector('strong').textContent;
+    expect(firstLine).not.toContain('2021');
+    
+    // URLリンクが二行目以降に表示されていることを確認
+    const link = firstItem.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toBe('https://example.com/paper1');
   });
   
   test('should filter publications by year', () => {
@@ -110,9 +118,10 @@ describe('Publications Component', () => {
     // 2021年の出版物のみが表示されていることを確認
     const items2021 = screen.getAllByRole('listitem');
     expect(items2021.length).toBe(1);
-    expect(items2021[0].textContent).toContain('2021');
     expect(items2021[0].textContent).toContain('ISOM21');
     expect(items2021[0].textContent).not.toContain('MMS2022');
+    
+    // 年度は内部的に保持されていることを確認（フィルタリングが機能している）
     
     // 2022年に変更
     fireEvent.change(yearSelect, { target: { value: '2022' } });
@@ -120,9 +129,13 @@ describe('Publications Component', () => {
     // 2022年の出版物のみが表示されていることを確認
     const items2022 = screen.getAllByRole('listitem');
     expect(items2022.length).toBe(1);
-    expect(items2022[0].textContent).toContain('2022');
     expect(items2022[0].textContent).toContain('MMS2022');
     expect(items2022[0].textContent).not.toContain('ISOM21');
+    
+    // URLリンクが二行目以降に表示されていることを確認
+    const link2022 = items2022[0].querySelector('a');
+    expect(link2022).not.toBeNull();
+    expect(link2022.getAttribute('href')).toBe('https://example.com/paper2');
   });
   
   test('should display publications in Japanese when language is set to Japanese', () => {
@@ -142,11 +155,18 @@ describe('Publications Component', () => {
     // 日本語の内容が含まれていることを確認
     // 注: 著者とタイトルの分離に依存せず、日本語の内容が表示されていることを確認
     const firstItem = publicationItems[0];
-    expect(firstItem.textContent).toContain('2021');
     expect(firstItem.textContent).toContain('ISOM21');
     
     // 日本語の内容が表示されていることを確認
     expect(firstItem.textContent).toContain('自己参照型');
     expect(firstItem.textContent).toContain('冨岡');
+    
+    // 一行目に年が表示されていないことを確認
+    const firstLine = firstItem.querySelector('strong').textContent;
+    expect(firstLine).not.toContain('2021');
+    
+    // URLリンクが二行目以降に表示されていることを確認
+    const link = firstItem.querySelector('a');
+    expect(link).not.toBeNull();
   });
 });

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -28,7 +28,13 @@ function Publications() {
         year: year,
         journal: pub.journalConference,
         date: pub.date,
-        webLink: pub.webLink
+        webLink: pub.webLink,
+        doi: pub.doi,
+        type: pub.type,
+        review: pub.review,
+        authorship: pub.authorship,
+        presentationType: pub.presentationType,
+        others: pub.others
       };
     });
   }, []);
@@ -72,16 +78,77 @@ function Publications() {
 
       <ul style={{ marginTop: "1rem" }}>
         {filteredPublications.map((pub) => (
-          <li key={pub.id} style={{ marginBottom: "1rem" }}>
+          <li key={pub.id} style={{ marginBottom: "1.5rem" }}>
+            {/* 一行目: タイトル */}
             <strong>
               {language === 'ja' && pub.japanese ? pub.japanese : pub.name}
-            </strong><br />
-            <div>{pub.journal}</div>
+            </strong>
+            
+            {/* 二行目: タグ（Authorship、type、Review、Presentation） */}
+            <div className="tags-container" style={{ marginTop: "0.5rem", display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+              {pub.authorship && (
+                <span className="tag" style={{
+                  backgroundColor: "#f0f0f0",
+                  padding: "0.2rem 0.5rem",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.85rem"
+                }}>
+                  {pub.authorship}
+                </span>
+              )}
+              {pub.type && (
+                <span className="tag" style={{
+                  backgroundColor: "#f0f0f0",
+                  padding: "0.2rem 0.5rem",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.85rem"
+                }}>
+                  {pub.type}
+                </span>
+              )}
+              {pub.review && (
+                <span className="tag" style={{
+                  backgroundColor: "#f0f0f0",
+                  padding: "0.2rem 0.5rem",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.85rem"
+                }}>
+                  {pub.review}
+                </span>
+              )}
+              {pub.presentationType && (
+                <span className="tag" style={{
+                  backgroundColor: "#f0f0f0",
+                  padding: "0.2rem 0.5rem",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.85rem"
+                }}>
+                  {pub.presentationType}
+                </span>
+              )}
+            </div>
+            
+            {/* 三行目: ジャーナル名 */}
+            <div style={{ marginTop: "0.5rem" }}>{pub.journal}</div>
+            
+            {/* 四行目以降: DOI、URL、Others */}
+            {pub.doi && (
+              <div style={{ marginTop: "0.25rem" }}>
+                DOI: <a href={`https://doi.org/${pub.doi}`} target="_blank" rel="noopener noreferrer">
+                  {pub.doi}
+                </a>
+              </div>
+            )}
             {pub.webLink && (
-              <div>
+              <div style={{ marginTop: "0.25rem" }}>
                 <a href={pub.webLink} target="_blank" rel="noopener noreferrer">
                   {pub.webLink}
                 </a>
+              </div>
+            )}
+            {pub.others && (
+              <div style={{ marginTop: "0.5rem", fontSize: "0.9rem", color: "#555" }}>
+                {pub.others}
               </div>
             )}
           </li>

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -72,13 +72,17 @@ function Publications() {
 
       <ul style={{ marginTop: "1rem" }}>
         {filteredPublications.map((pub) => (
-          <li key={pub.id} style={{ marginBottom: "0.5rem" }}>
+          <li key={pub.id} style={{ marginBottom: "1rem" }}>
             <strong>
               {language === 'ja' && pub.japanese ? pub.japanese : pub.name}
-            </strong> ({pub.year})<br />
-            {pub.journal}
+            </strong><br />
+            <div>{pub.journal}</div>
             {pub.webLink && (
-              <span> [<a href={pub.webLink} target="_blank" rel="noopener noreferrer">Link</a>]</span>
+              <div>
+                <a href={pub.webLink} target="_blank" rel="noopener noreferrer">
+                  {pub.webLink}
+                </a>
+              </div>
             )}
           </li>
         ))}

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -21,7 +21,7 @@ function Publications() {
     return match ? parseInt(match[1], 10) : null;
   };
 
-  // 出版物データを最小限の整形で処理
+  // 出版物データを最小限の整形で処理し、新しい順に並べる
   const formattedPublications = useMemo(() => {
     return publicationsData.map((pub, index) => {
       // 年度を抽出（フィルタリングに必要）
@@ -43,6 +43,9 @@ function Publications() {
         presentationType: pub.presentationType,
         others: pub.others
       };
+    }).sort((a, b) => {
+      // 新しい順に並べる（年が新しい順）
+      return (b.year || 0) - (a.year || 0);
     });
   }, []);
 
@@ -258,7 +261,7 @@ function Publications() {
         </div>
       )}
 
-      <ul style={{ marginTop: "1rem" }}>
+      <ol style={{ marginTop: "1rem" }}>
         {filteredPublications.map((pub) => (
           <li key={pub.id} style={{ marginBottom: "1.5rem" }}>
             {/* 一行目: タイトル */}
@@ -320,7 +323,7 @@ function Publications() {
             )}
           </li>
         ))}
-      </ul>
+      </ol>
     </div>
   );
 }

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -3,8 +3,14 @@ import { useLanguage } from "../contexts/LanguageContext";
 import publicationsData from "../data/publications.json";
 
 function Publications() {
-  const [selectedYear, setSelectedYear] = useState("All");
-  const [selectedTags, setSelectedTags] = useState([]);
+  const [openDropdown, setOpenDropdown] = useState(null);
+  const [selectedFilters, setSelectedFilters] = useState({
+    year: [],
+    authorship: [],
+    type: [],
+    review: [],
+    presentationType: []
+  });
   const { language } = useLanguage();
 
   // 日付から年を抽出する関数
@@ -40,120 +46,215 @@ function Publications() {
     });
   }, []);
 
-  // ユニークな年度を抽出
-  const years = useMemo(() => {
-    const uniqueYears = Array.from(
-      new Set(formattedPublications.map((pub) => pub.year).filter(Boolean))
-    ).sort();
-    return ["All", ...uniqueYears];
+  // 利用可能なフィルターオプションを抽出
+  const filterOptions = useMemo(() => {
+    const options = {
+      year: [],
+      authorship: [],
+      type: [],
+      review: [],
+      presentationType: []
+    };
+    
+    formattedPublications.forEach(pub => {
+      if (pub.year && !options.year.includes(pub.year.toString())) {
+        options.year.push(pub.year.toString());
+      }
+      if (pub.authorship && !options.authorship.includes(pub.authorship)) {
+        options.authorship.push(pub.authorship);
+      }
+      if (pub.type && !options.type.includes(pub.type)) {
+        options.type.push(pub.type);
+      }
+      if (pub.review && !options.review.includes(pub.review)) {
+        options.review.push(pub.review);
+      }
+      if (pub.presentationType && !options.presentationType.includes(pub.presentationType)) {
+        options.presentationType.push(pub.presentationType);
+      }
+    });
+    
+    return options;
   }, [formattedPublications]);
-
-  // タグによるフィルタリング
+  
+  // フィルタリング
   const filteredPublications = useMemo(() => {
     return formattedPublications.filter((pub) => {
       // 年度フィルター
-      if (selectedYear !== "All" && pub.year !== parseInt(selectedYear, 10)) {
+      if (selectedFilters.year.length > 0 && !selectedFilters.year.includes(pub.year?.toString())) {
         return false;
       }
       
-      // タグフィルター
-      if (selectedTags.length > 0) {
-        // 選択されたすべてのタグに一致するかチェック
-        for (const tag of selectedTags) {
-          const pubTags = [
-            pub.year?.toString(),
-            pub.authorship,
-            pub.type,
-            pub.review,
-            pub.presentationType
-          ].filter(Boolean);
-          
-          if (!pubTags.includes(tag)) {
-            return false;
-          }
-        }
+      // 著者の役割フィルター
+      if (selectedFilters.authorship.length > 0 && !selectedFilters.authorship.includes(pub.authorship)) {
+        return false;
+      }
+      
+      // タイプフィルター
+      if (selectedFilters.type.length > 0 && !selectedFilters.type.includes(pub.type)) {
+        return false;
+      }
+      
+      // レビューフィルター
+      if (selectedFilters.review.length > 0 && !selectedFilters.review.includes(pub.review)) {
+        return false;
+      }
+      
+      // 発表タイプフィルター
+      if (selectedFilters.presentationType.length > 0 && !selectedFilters.presentationType.includes(pub.presentationType)) {
+        return false;
       }
       
       return true;
     });
-  }, [formattedPublications, selectedYear, selectedTags]);
+  }, [formattedPublications, selectedFilters]);
 
-  // タグをクリックしたときの処理
-  const handleTagClick = (tag) => {
-    if (selectedTags.includes(tag)) {
-      // すでに選択されている場合は削除
-      setSelectedTags(selectedTags.filter(t => t !== tag));
+  // ドロップダウンを開く/閉じる処理
+  const toggleDropdown = (dropdown) => {
+    if (openDropdown === dropdown) {
+      setOpenDropdown(null);
     } else {
-      // 選択されていない場合は追加
-      setSelectedTags([...selectedTags, tag]);
+      setOpenDropdown(dropdown);
     }
+  };
+
+  // フィルターを選択/解除する処理
+  const toggleFilter = (category, value) => {
+    setSelectedFilters(prev => {
+      const newFilters = { ...prev };
+      if (newFilters[category].includes(value)) {
+        // すでに選択されている場合は削除
+        newFilters[category] = newFilters[category].filter(v => v !== value);
+      } else {
+        // 選択されていない場合は追加
+        newFilters[category] = [...newFilters[category], value];
+      }
+      return newFilters;
+    });
   };
 
   // フィルターをリセットする処理
   const resetFilters = () => {
-    setSelectedYear("All");
-    setSelectedTags([]);
+    setSelectedFilters({
+      year: [],
+      authorship: [],
+      type: [],
+      review: [],
+      presentationType: []
+    });
   };
 
+  // フィルターが選択されているかどうか
+  const hasActiveFilters = Object.values(selectedFilters).some(filters => filters.length > 0);
+
   // 言語に応じたラベル
-  const filterLabel = language === 'ja' ? '絞り込み (年度)' : 'Filter by Year';
-  const allLabel = language === 'ja' ? 'すべて' : 'All';
+  const filterLabels = {
+    year: language === 'ja' ? '年度' : 'Year',
+    authorship: language === 'ja' ? '著者の役割' : 'Authorship',
+    type: language === 'ja' ? '種類' : 'Type',
+    review: language === 'ja' ? 'レビュー' : 'Review',
+    presentationType: language === 'ja' ? '発表タイプ' : 'Presentation Type'
+  };
   const resetLabel = language === 'ja' ? 'フィルターをリセット' : 'Reset Filters';
 
   return (
     <div style={{ padding: "0" }}>
-      <div>
-        <label htmlFor="year-select">{filterLabel}: </label>
-        <select
-          id="year-select"
-          value={selectedYear}
-          onChange={(e) => setSelectedYear(e.target.value)}
-        >
-          {years.map((year) => (
-            <option key={year} value={year}>
-              {year === "All" ? allLabel : year}
-            </option>
-          ))}
-        </select>
+      {/* フィルターボタン */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginBottom: "1rem" }}>
+        {Object.entries(filterLabels).map(([category, label]) => (
+          <div key={category} style={{ position: "relative" }}>
+            <button
+              onClick={() => toggleDropdown(category)}
+              style={{
+                padding: "0.5rem 1rem",
+                backgroundColor: selectedFilters[category].length > 0 ? "#c0e0ff" : "#f0f0f0",
+                border: "none",
+                borderRadius: "0.25rem",
+                cursor: "pointer",
+                fontWeight: selectedFilters[category].length > 0 ? "bold" : "normal"
+              }}
+            >
+              {label} ▼
+            </button>
+            
+            {openDropdown === category && (
+              <div
+                data-testid={`${category}-dropdown`}
+                style={{
+                  position: "absolute",
+                  top: "100%",
+                  left: 0,
+                  zIndex: 10,
+                  backgroundColor: "white",
+                  border: "1px solid #ccc",
+                  borderRadius: "0.25rem",
+                  padding: "0.5rem",
+                  minWidth: "200px",
+                  boxShadow: "0 2px 5px rgba(0,0,0,0.2)"
+                }}
+              >
+                {filterOptions[category].map(option => (
+                  <div key={option} style={{ marginBottom: "0.25rem" }}>
+                    <label style={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
+                      <input
+                        type="checkbox"
+                        checked={selectedFilters[category].includes(option)}
+                        onChange={() => toggleFilter(category, option)}
+                        style={{ marginRight: "0.5rem" }}
+                      />
+                      {option}
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
       
       {/* フィルターリセットボタン */}
-      {(selectedTags.length > 0 || selectedYear !== "All") && (
-        <button
+      {hasActiveFilters && (
+        <button 
           onClick={resetFilters}
           style={{
-            marginLeft: "1rem",
-            padding: "0.25rem 0.5rem",
+            padding: "0.5rem 1rem",
             backgroundColor: "#f0f0f0",
             border: "none",
             borderRadius: "0.25rem",
-            cursor: "pointer"
+            cursor: "pointer",
+            marginLeft: "0.5rem"
           }}
         >
           {resetLabel}
         </button>
       )}
       
-      {/* 選択されているタグを表示 */}
-      {selectedTags.length > 0 && (
-        <div style={{ marginTop: "0.5rem" }}>
-          <span>{language === 'ja' ? '選択中のタグ: ' : 'Selected tags: '}</span>
-          {selectedTags.map(tag => (
-            <span
-              key={tag}
-              style={{
-                backgroundColor: "#e0e0e0",
-                padding: "0.2rem 0.5rem",
-                borderRadius: "0.25rem",
-                fontSize: "0.85rem",
-                marginRight: "0.5rem",
-                cursor: "pointer"
-              }}
-              onClick={() => handleTagClick(tag)}
-            >
-              {tag} ✕
-            </span>
-          ))}
+      {/* 選択されているフィルターを表示 */}
+      {hasActiveFilters && (
+        <div style={{ marginTop: "0.5rem", marginBottom: "1rem" }}>
+          {Object.entries(selectedFilters).map(([category, values]) => 
+            values.length > 0 && (
+              <div key={category} style={{ marginBottom: "0.25rem" }}>
+                <span style={{ fontWeight: "bold" }}>{filterLabels[category]}: </span>
+                {values.map(value => (
+                  <span 
+                    key={value}
+                    style={{
+                      backgroundColor: "#e0e0e0",
+                      padding: "0.2rem 0.5rem",
+                      borderRadius: "0.25rem",
+                      fontSize: "0.85rem",
+                      marginRight: "0.5rem",
+                      cursor: "pointer"
+                    }}
+                    onClick={() => toggleFilter(category, value)}
+                  >
+                    {value} ✕
+                  </span>
+                ))}
+              </div>
+            )
+          )}
         </div>
       )}
 
@@ -168,77 +269,27 @@ function Publications() {
             {/* 二行目: タグ（Year、Authorship、type、Review、Presentation） */}
             <div className="tags-container" style={{ marginTop: "0.5rem", display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
               {pub.year && (
-                <span
-                  className="tag"
-                  style={{
-                    backgroundColor: selectedTags.includes(pub.year.toString()) ? "#c0e0ff" : "#f0f0f0",
-                    padding: "0.2rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    fontSize: "0.85rem",
-                    cursor: "pointer"
-                  }}
-                  onClick={() => handleTagClick(pub.year.toString())}
-                >
+                <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
                   {pub.year}
                 </span>
               )}
               {pub.authorship && (
-                <span
-                  className="tag"
-                  style={{
-                    backgroundColor: selectedTags.includes(pub.authorship) ? "#c0e0ff" : "#f0f0f0",
-                    padding: "0.2rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    fontSize: "0.85rem",
-                    cursor: "pointer"
-                  }}
-                  onClick={() => handleTagClick(pub.authorship)}
-                >
+                <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
                   {pub.authorship}
                 </span>
               )}
               {pub.type && (
-                <span
-                  className="tag"
-                  style={{
-                    backgroundColor: selectedTags.includes(pub.type) ? "#c0e0ff" : "#f0f0f0",
-                    padding: "0.2rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    fontSize: "0.85rem",
-                    cursor: "pointer"
-                  }}
-                  onClick={() => handleTagClick(pub.type)}
-                >
+                <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
                   {pub.type}
                 </span>
               )}
               {pub.review && (
-                <span
-                  className="tag"
-                  style={{
-                    backgroundColor: selectedTags.includes(pub.review) ? "#c0e0ff" : "#f0f0f0",
-                    padding: "0.2rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    fontSize: "0.85rem",
-                    cursor: "pointer"
-                  }}
-                  onClick={() => handleTagClick(pub.review)}
-                >
+                <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
                   {pub.review}
                 </span>
               )}
               {pub.presentationType && (
-                <span
-                  className="tag"
-                  style={{
-                    backgroundColor: selectedTags.includes(pub.presentationType) ? "#c0e0ff" : "#f0f0f0",
-                    padding: "0.2rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    fontSize: "0.85rem",
-                    cursor: "pointer"
-                  }}
-                  onClick={() => handleTagClick(pub.presentationType)}
-                >
+                <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
                   {pub.presentationType}
                 </span>
               )}

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -14,43 +14,21 @@ function Publications() {
     return match ? parseInt(match[1], 10) : null;
   };
 
-  // 出版物データを整形
+  // 出版物データを最小限の整形で処理
   const formattedPublications = useMemo(() => {
     return publicationsData.map((pub, index) => {
-      // 名前から著者とタイトルを分離
-      const nameParts = pub.name.split(', "');
-      const authors = nameParts[0];
-      const title = nameParts.length > 1 
-        ? nameParts[1].replace(/"/g, '') 
-        : pub.name;
-
-      // 日本語の名前とタイトルを分離（存在する場合）
-      let japaneseAuthors = '';
-      let japaneseTitle = '';
-      if (pub.japanese) {
-        const jaNameParts = pub.japanese.split(', "');
-        japaneseAuthors = jaNameParts[0];
-        japaneseTitle = jaNameParts.length > 1 
-          ? jaNameParts[1].replace(/"/g, '') 
-          : pub.japanese;
-      }
-
-      // 年度を抽出
+      // 年度を抽出（フィルタリングに必要）
       const year = extractYear(pub.date);
 
+      // 必要最小限のプロパティのみを返す
       return {
         id: index,
-        title: title,
-        japaneseTitle: japaneseTitle,
-        authors: authors,
-        japaneseAuthors: japaneseAuthors,
+        name: pub.name,
+        japanese: pub.japanese,
         year: year,
         journal: pub.journalConference,
         date: pub.date,
-        webLink: pub.webLink,
-        type: pub.type,
-        presentationType: pub.presentationType,
-        site: pub.site
+        webLink: pub.webLink
       };
     });
   }, []);
@@ -96,21 +74,11 @@ function Publications() {
         {filteredPublications.map((pub) => (
           <li key={pub.id} style={{ marginBottom: "0.5rem" }}>
             <strong>
-              {language === 'ja' && pub.japaneseTitle ? pub.japaneseTitle : pub.title}
+              {language === 'ja' && pub.japanese ? pub.japanese : pub.name}
             </strong> ({pub.year})<br />
-            <em>
-              {language === 'ja' && pub.japaneseAuthors ? pub.japaneseAuthors : pub.authors}
-            </em> - {pub.journal}
+            {pub.journal}
             {pub.webLink && (
               <span> [<a href={pub.webLink} target="_blank" rel="noopener noreferrer">Link</a>]</span>
-            )}
-            
-            {/* 英語のタイトルと著者名を非表示で保持（テスト用） */}
-            {language === 'ja' && pub.title && (
-              <span style={{ display: 'none' }}>{pub.title}</span>
-            )}
-            {language === 'ja' && pub.authors && (
-              <span style={{ display: 'none' }}>{pub.authors}</span>
             )}
           </li>
         ))}

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -4,6 +4,7 @@ import publicationsData from "../data/publications.json";
 
 function Publications() {
   const [selectedYear, setSelectedYear] = useState("All");
+  const [selectedTags, setSelectedTags] = useState([]);
   const { language } = useLanguage();
 
   // 日付から年を抽出する関数
@@ -47,17 +48,57 @@ function Publications() {
     return ["All", ...uniqueYears];
   }, [formattedPublications]);
 
-  // 年度フィルタリング
+  // タグによるフィルタリング
   const filteredPublications = useMemo(() => {
     return formattedPublications.filter((pub) => {
-      if (selectedYear === "All") return true;
-      return pub.year === parseInt(selectedYear, 10);
+      // 年度フィルター
+      if (selectedYear !== "All" && pub.year !== parseInt(selectedYear, 10)) {
+        return false;
+      }
+      
+      // タグフィルター
+      if (selectedTags.length > 0) {
+        // 選択されたすべてのタグに一致するかチェック
+        for (const tag of selectedTags) {
+          const pubTags = [
+            pub.year?.toString(),
+            pub.authorship,
+            pub.type,
+            pub.review,
+            pub.presentationType
+          ].filter(Boolean);
+          
+          if (!pubTags.includes(tag)) {
+            return false;
+          }
+        }
+      }
+      
+      return true;
     });
-  }, [formattedPublications, selectedYear]);
+  }, [formattedPublications, selectedYear, selectedTags]);
+
+  // タグをクリックしたときの処理
+  const handleTagClick = (tag) => {
+    if (selectedTags.includes(tag)) {
+      // すでに選択されている場合は削除
+      setSelectedTags(selectedTags.filter(t => t !== tag));
+    } else {
+      // 選択されていない場合は追加
+      setSelectedTags([...selectedTags, tag]);
+    }
+  };
+
+  // フィルターをリセットする処理
+  const resetFilters = () => {
+    setSelectedYear("All");
+    setSelectedTags([]);
+  };
 
   // 言語に応じたラベル
   const filterLabel = language === 'ja' ? '絞り込み (年度)' : 'Filter by Year';
   const allLabel = language === 'ja' ? 'すべて' : 'All';
+  const resetLabel = language === 'ja' ? 'フィルターをリセット' : 'Reset Filters';
 
   return (
     <div style={{ padding: "0" }}>
@@ -75,6 +116,46 @@ function Publications() {
           ))}
         </select>
       </div>
+      
+      {/* フィルターリセットボタン */}
+      {(selectedTags.length > 0 || selectedYear !== "All") && (
+        <button
+          onClick={resetFilters}
+          style={{
+            marginLeft: "1rem",
+            padding: "0.25rem 0.5rem",
+            backgroundColor: "#f0f0f0",
+            border: "none",
+            borderRadius: "0.25rem",
+            cursor: "pointer"
+          }}
+        >
+          {resetLabel}
+        </button>
+      )}
+      
+      {/* 選択されているタグを表示 */}
+      {selectedTags.length > 0 && (
+        <div style={{ marginTop: "0.5rem" }}>
+          <span>{language === 'ja' ? '選択中のタグ: ' : 'Selected tags: '}</span>
+          {selectedTags.map(tag => (
+            <span
+              key={tag}
+              style={{
+                backgroundColor: "#e0e0e0",
+                padding: "0.2rem 0.5rem",
+                borderRadius: "0.25rem",
+                fontSize: "0.85rem",
+                marginRight: "0.5rem",
+                cursor: "pointer"
+              }}
+              onClick={() => handleTagClick(tag)}
+            >
+              {tag} ✕
+            </span>
+          ))}
+        </div>
+      )}
 
       <ul style={{ marginTop: "1rem" }}>
         {filteredPublications.map((pub) => (
@@ -84,45 +165,80 @@ function Publications() {
               {language === 'ja' && pub.japanese ? pub.japanese : pub.name}
             </strong>
             
-            {/* 二行目: タグ（Authorship、type、Review、Presentation） */}
+            {/* 二行目: タグ（Year、Authorship、type、Review、Presentation） */}
             <div className="tags-container" style={{ marginTop: "0.5rem", display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+              {pub.year && (
+                <span
+                  className="tag"
+                  style={{
+                    backgroundColor: selectedTags.includes(pub.year.toString()) ? "#c0e0ff" : "#f0f0f0",
+                    padding: "0.2rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.85rem",
+                    cursor: "pointer"
+                  }}
+                  onClick={() => handleTagClick(pub.year.toString())}
+                >
+                  {pub.year}
+                </span>
+              )}
               {pub.authorship && (
-                <span className="tag" style={{
-                  backgroundColor: "#f0f0f0",
-                  padding: "0.2rem 0.5rem",
-                  borderRadius: "0.25rem",
-                  fontSize: "0.85rem"
-                }}>
+                <span
+                  className="tag"
+                  style={{
+                    backgroundColor: selectedTags.includes(pub.authorship) ? "#c0e0ff" : "#f0f0f0",
+                    padding: "0.2rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.85rem",
+                    cursor: "pointer"
+                  }}
+                  onClick={() => handleTagClick(pub.authorship)}
+                >
                   {pub.authorship}
                 </span>
               )}
               {pub.type && (
-                <span className="tag" style={{
-                  backgroundColor: "#f0f0f0",
-                  padding: "0.2rem 0.5rem",
-                  borderRadius: "0.25rem",
-                  fontSize: "0.85rem"
-                }}>
+                <span
+                  className="tag"
+                  style={{
+                    backgroundColor: selectedTags.includes(pub.type) ? "#c0e0ff" : "#f0f0f0",
+                    padding: "0.2rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.85rem",
+                    cursor: "pointer"
+                  }}
+                  onClick={() => handleTagClick(pub.type)}
+                >
                   {pub.type}
                 </span>
               )}
               {pub.review && (
-                <span className="tag" style={{
-                  backgroundColor: "#f0f0f0",
-                  padding: "0.2rem 0.5rem",
-                  borderRadius: "0.25rem",
-                  fontSize: "0.85rem"
-                }}>
+                <span
+                  className="tag"
+                  style={{
+                    backgroundColor: selectedTags.includes(pub.review) ? "#c0e0ff" : "#f0f0f0",
+                    padding: "0.2rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.85rem",
+                    cursor: "pointer"
+                  }}
+                  onClick={() => handleTagClick(pub.review)}
+                >
                   {pub.review}
                 </span>
               )}
               {pub.presentationType && (
-                <span className="tag" style={{
-                  backgroundColor: "#f0f0f0",
-                  padding: "0.2rem 0.5rem",
-                  borderRadius: "0.25rem",
-                  fontSize: "0.85rem"
-                }}>
+                <span
+                  className="tag"
+                  style={{
+                    backgroundColor: selectedTags.includes(pub.presentationType) ? "#c0e0ff" : "#f0f0f0",
+                    padding: "0.2rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.85rem",
+                    cursor: "pointer"
+                  }}
+                  onClick={() => handleTagClick(pub.presentationType)}
+                >
                   {pub.presentationType}
                 </span>
               )}


### PR DESCRIPTION
## 概要
このプルリクエストでは、出版物ページ（Publications）の表示方法を改善し、ユーザーエクスペリエンスを向上させました。

## 変更内容

### 1. フィルタリング機能の強化
- 年度フィルター（セレクトボックス）を削除し、より直感的なドロップダウンメニュー付きのフィルターボタンを実装
- 各フィルターカテゴリ（年度、著者の役割、種類、レビュー、発表タイプ）ごとにフィルターボタンを表示
- フィルターボタンをクリックすると、チェックボックス付きのドロップダウンメニューが表示される
- 選択されたフィルターは色が変わり、視覚的に区別できるようにした
- 選択されているフィルターを一覧表示し、クリックで解除できるようにした
- フィルターをリセットするボタンを追加

### 2. 表示方法の改善
- 出版物を新しい順（年が新しい順）に並べるように変更
- 箇条書き（`<ul>`）ではなく、数字の箇条書き（`<ol>`）を使用するように変更
- タグの表示を簡略化し、視認性を向上

## 変更理由
1. **フィルタリングの使いやすさ向上**: 従来の年度フィルターでは1つの条件でしかフィルタリングできませんでしたが、新しい実装では複数の条件を組み合わせてフィルタリングできるようになりました。
2. **情報の優先度の明確化**: 新しい順に並べることで、最新の出版物が優先的に表示されるようになりました。
3. **視認性の向上**: 数字の箇条書きを使用することで、出版物の順序が明確になりました。

## テスト方法
1. 出版物ページにアクセスし、出版物が新しい順に並んでいることを確認
2. 各フィルターボタンをクリックし、ドロップダウンメニューが表示されることを確認
3. 各フィルターを選択し、出版物が正しくフィルタリングされることを確認
4. 複数のフィルターを組み合わせて、出版物が正しくフィルタリングされることを確認
5. フィルターをリセットし、すべての出版物が表示されることを確認
6. 日本語モードで表示し、日本語の内容が正しく表示されることを確認

## テスト結果
すべてのテストが正常に通過しました：
```
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```