### PR TITLE
プルダウンメニュー外クリックでの閉じる機能追加

### DIFF
--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -185,4 +185,32 @@ describe('Publications Component', () => {
     expect(screen.getByText('著者の役割 ▼')).toBeInTheDocument();
     expect(screen.getByText('種類 ▼')).toBeInTheDocument();
   });
+
+  test('should close dropdown when clicking outside', () => {
+    // テスト内容: プルダウンメニュー以外の場所をクリックするとメニューが閉じることを確認
+    renderWithLanguageProvider(<Publications />);
+
+    // 年のフィルターボタンをクリックしてドロップダウンを開く
+    const yearFilterButton = screen.getByText('年度 ▼');
+    fireEvent.click(yearFilterButton);
+
+    // ドロップダウンが表示されていることを確認
+    const yearDropdown = screen.getByTestId('year-dropdown');
+    expect(yearDropdown).toBeInTheDocument();
+
+    // ドキュメントのbodyをクリック（メニュー外のクリックをシミュレート）
+    fireEvent.mouseDown(document.body); // mouseDown イベントを使用
+
+    // ドロップダウンが閉じている（非表示になっている）ことを確認
+    expect(screen.queryByTestId('year-dropdown')).not.toBeInTheDocument();
+
+    // 別のフィルター（著者の役割）でも同様にテスト
+    const authorshipFilterButton = screen.getByText('著者の役割 ▼');
+    fireEvent.click(authorshipFilterButton);
+    const authorshipDropdown = screen.getByTestId('authorship-dropdown');
+    expect(authorshipDropdown).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('authorship-dropdown')).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import { useLanguage } from "../contexts/LanguageContext";
 import publicationsData from "../data/publications.json";
 
@@ -12,6 +12,7 @@ function Publications() {
     presentationType: []
   });
   const { language } = useLanguage();
+  const filterRefs = useRef({}); // 各フィルター要素の参照を保持
 
   // 日付から年を抽出する関数
   const extractYear = (dateString) => {
@@ -160,12 +161,35 @@ function Publications() {
   };
   const resetLabel = language === 'ja' ? 'フィルターをリセット' : 'Reset Filters';
 
+  // ドロップダウンの外側をクリックしたときに閉じる処理
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (openDropdown) {
+        const currentFilterRef = filterRefs.current[openDropdown];
+        if (currentFilterRef && !currentFilterRef.contains(event.target)) {
+          setOpenDropdown(null);
+        }
+      }
+    };
+
+    // イベントリスナーを追加
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      // クリーンアップ時にイベントリスナーを削除
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [openDropdown]); // openDropdown が変更されたときにのみ再実行
+
   return (
     <div style={{ padding: "0" }}>
       {/* フィルターボタン */}
       <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginBottom: "1rem" }}>
         {Object.entries(filterLabels).map(([category, label]) => (
-          <div key={category} style={{ position: "relative" }}>
+          <div
+            key={category}
+            style={{ position: "relative" }}
+            ref={el => filterRefs.current[category] = el} // ref を設定
+          >
             <button
               onClick={() => toggleDropdown(category)}
               style={{
@@ -195,6 +219,7 @@ function Publications() {
                   minWidth: "200px",
                   boxShadow: "0 2px 5px rgba(0,0,0,0.2)"
                 }}
+                // ref は親の div に設定済みなので、ここでは不要
               >
                 {filterOptions[category].map(option => (
                   <div key={option} style={{ marginBottom: "0.25rem" }}>


### PR DESCRIPTION
## 概要
Publicationsページの絞り込み機能について、プルダウンメニュー以外の場所をクリックしたらメニューが自動的に閉じるように修正しました。

## 変更詳細

### 問題点
現在の実装では、絞り込みのプルダウンメニューを開いた後、再度同じボタンをクリックしない限りメニューが閉じません。これはユーザビリティの観点から改善の余地がありました。

### 解決策
プルダウンメニュー以外の場所をクリックすると、メニューが自動的に閉じるように実装しました。これは一般的なUIパターンであり、ユーザーエクスペリエンスを向上させます。

### 実装方法
1. `useRef` を使用して各フィルターボタンとドロップダウンメニューのコンテナ要素への参照を保持
2. `useEffect` フックを使用して `mousedown` イベントリスナーを `document` に設定
3. ユーザーがクリックした場所が開いているドロップダウンメニューの外部であるかを確認し、外部であれば自動的にメニューを閉じる
4. コンポーネントのアンマウント時にイベントリスナーを削除するクリーンアップ処理を実装

## テスト
TDDアプローチに従い、以下のテストを実装しました：
- `should close dropdown when clicking outside` - プルダウンメニュー以外の場所をクリックするとメニューが閉じることを確認するテスト

すべてのテストが成功し、機能が正しく動作することを確認しました。

## 変更ファイル
- `src/__tests__/Publications.test.jsx` - 新しいテストケースを追加
- `src/pages/Publications.jsx` - プルダウンメニュー外クリックでの閉じる機能を実装