### PR TITLE
出版物ページの日付処理と表示の改善

### DIFF
--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -368,6 +368,42 @@ describe('Publications Component', () => {
     expect(sortOrderSelector.value).toBe('type');
   });
   
+  test('should sort publications by sortableDate in chronological order', () => {
+    // テスト内容: 出版物が開始日に基づいて時系列順にソートされることを確認
+    
+    // 実際のPublicationsコンポーネントをレンダリング
+    renderWithLanguageProvider(<Publications />);
+    
+    // 時系列順に切り替え
+    const sortOrderSelector = screen.getByRole('combobox');
+    fireEvent.change(sortOrderSelector, { target: { value: 'chronological' } });
+    
+    // 出版物リストを取得
+    const publicationItems = document.querySelectorAll('ol li');
+    
+    // 少なくとも1つの出版物があることを確認
+    expect(publicationItems.length).toBeGreaterThan(0);
+    
+    // 出版物が時系列順（新しい順）でソートされていることを確認
+    // 実際のデータを使用するため、特定の出版物名ではなく、日付の順序を確認
+    
+    // 各出版物の日付を取得
+    const dates = Array.from(publicationItems).map(item => {
+      // 日付を含むタグを探す
+      const tags = item.querySelectorAll('.tag');
+      const yearTag = Array.from(tags).find(tag => /\d{4}/.test(tag.textContent));
+      return yearTag ? parseInt(yearTag.textContent.match(/\d{4}/)[0], 10) : 0;
+    });
+    
+    // 日付が降順（新しい順）であることを確認
+    for (let i = 1; i < dates.length; i++) {
+      // 日付が0の場合はスキップ（日付が取得できなかった場合）
+      if (dates[i] === 0 || dates[i-1] === 0) continue;
+      
+      // 前の日付が現在の日付以上であることを確認（同じ年の場合もあるため）
+      expect(dates[i-1]).toBeGreaterThanOrEqual(dates[i]);
+    }
+  });
   test('should display publications in groups with separate numbering', () => {
     // テスト内容: グループ表示機能が正しく動作することを確認
     renderWithLanguageProvider(<Publications />);

--- a/src/__tests__/Publications.test.jsx
+++ b/src/__tests__/Publications.test.jsx
@@ -130,6 +130,55 @@ describe('Publications Component', () => {
     expect(resetGroups.length).toBe(initialCount);
   });
   
+  test('should filter publications with array presentation types correctly', () => {
+    // テスト内容: 配列形式のpresentationTypeを持つ出版物が正しくフィルタリングされることを確認
+    renderWithLanguageProvider(<Publications />);
+    
+    // 発表タイプのフィルターボタンをクリック
+    const presentationTypeButton = screen.getByText('発表タイプ ▼');
+    fireEvent.click(presentationTypeButton);
+    
+    // ドロップダウンメニューが表示されることを確認
+    const presentationTypeDropdown = screen.getByTestId('presentationType-dropdown');
+    expect(presentationTypeDropdown).toBeInTheDocument();
+    
+    // 発表タイプのオプションを取得
+    const presentationTypeOptions = presentationTypeDropdown.querySelectorAll('input[type="checkbox"]');
+    expect(presentationTypeOptions.length).toBeGreaterThan(0);
+    
+    // 初期状態での出版物アイテム数を記録
+    const initialItems = document.querySelectorAll('ol li');
+    const initialItemCount = initialItems.length;
+    expect(initialItemCount).toBeGreaterThan(0);
+    
+    // 発表タイプのオプションの中からPosterを選択
+    // （配列形式のpresentationTypeを持つ出版物も含まれるはず）
+    const posterOption = Array.from(presentationTypeOptions)
+      .find(option => option.nextSibling.textContent.trim() === 'Poster');
+    
+    if (posterOption) {
+      fireEvent.click(posterOption);
+      
+      // フィルタリング後の出版物アイテムを取得
+      const filteredItems = document.querySelectorAll('ol li');
+      
+      // フィルタリングにより表示数が変わることを確認
+      expect(filteredItems.length).toBeGreaterThan(0);
+      expect(filteredItems.length).toBeLessThanOrEqual(initialItemCount);
+      
+      // フィルターをリセット
+      const resetButton = screen.getByText('フィルターをリセット');
+      fireEvent.click(resetButton);
+      
+      // リセット後は元の数の出版物アイテムが表示されていることを確認
+      const resetItems = document.querySelectorAll('ol li');
+      expect(resetItems.length).toBe(initialItemCount);
+    } else {
+      // Posterオプションが見つからない場合はテストをスキップ
+      console.log('Posterオプションが見つからないためテストをスキップします');
+    }
+  });
+  
   test('should show active filters with different color', () => {
     // テスト内容: アクティブなフィルターが異なる色で表示されることを確認
     renderWithLanguageProvider(<Publications />);
@@ -168,6 +217,55 @@ describe('Publications Component', () => {
     
     const inactiveAuthorshipFilter = screen.getByText('著者の役割 ▼');
     expect(inactiveAuthorshipFilter).toHaveAttribute('style', expect.stringContaining('background-color: rgb(240, 240, 240)'));
+  });
+  
+  test('should filter publications with array authorship correctly', () => {
+    // テスト内容: 配列形式のauthorshipを持つ出版物が正しくフィルタリングされることを確認
+    renderWithLanguageProvider(<Publications />);
+    
+    // 著者の役割のフィルターボタンをクリック
+    const authorshipButton = screen.getByText('著者の役割 ▼');
+    fireEvent.click(authorshipButton);
+    
+    // ドロップダウンメニューが表示されることを確認
+    const authorshipDropdown = screen.getByTestId('authorship-dropdown');
+    expect(authorshipDropdown).toBeInTheDocument();
+    
+    // 著者の役割のオプションを取得
+    const authorshipOptions = authorshipDropdown.querySelectorAll('input[type="checkbox"]');
+    expect(authorshipOptions.length).toBeGreaterThan(0);
+    
+    // 初期状態での出版物アイテム数を記録
+    const initialItems = document.querySelectorAll('ol li');
+    const initialItemCount = initialItems.length;
+    expect(initialItemCount).toBeGreaterThan(0);
+    
+    // 著者の役割のオプションの中からCorresponding authorを選択
+    // （配列形式のauthorshipを持つ出版物も含まれるはず）
+    const correspondingAuthorOption = Array.from(authorshipOptions)
+      .find(option => option.nextSibling.textContent.trim() === 'Corresponding author');
+    
+    if (correspondingAuthorOption) {
+      fireEvent.click(correspondingAuthorOption);
+      
+      // フィルタリング後の出版物アイテムを取得
+      const filteredItems = document.querySelectorAll('ol li');
+      
+      // フィルタリングにより表示数が変わることを確認
+      expect(filteredItems.length).toBeGreaterThan(0);
+      expect(filteredItems.length).toBeLessThanOrEqual(initialItemCount);
+      
+      // フィルターをリセット
+      const resetButton = screen.getByText('フィルターをリセット');
+      fireEvent.click(resetButton);
+      
+      // リセット後は元の数の出版物アイテムが表示されていることを確認
+      const resetItems = document.querySelectorAll('ol li');
+      expect(resetItems.length).toBe(initialItemCount);
+    } else {
+      // Corresponding authorオプションが見つからない場合はテストをスキップ
+      console.log('Corresponding authorオプションが見つからないためテストをスキップします');
+    }
   });
   
   test('should display publications in Japanese when language is set to Japanese', () => {

--- a/src/__tests__/csvToJson.test.js
+++ b/src/__tests__/csvToJson.test.js
@@ -222,4 +222,69 @@ No,"Test Author, ""Single Type""",テスト,Test Type,Reviewed,Lead author,Oral,
       }
     }
   });
+  
+  test('processes dates correctly into start and end dates', () => {
+    // テスト内容: 日付が正しく開始日と終了日に分割され、ソート可能な形式で格納されることを確認
+    
+    // テスト用のCSVデータを準備（様々な形式の日付を含む）
+    const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
+No,"Test Date Range",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2021年10月3日 → 2021年10月6日,,Test Site,Test Journal
+No,"Test Single Date",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2022年5月15日,,Test Site,Test Journal
+No,"Test Year Month Only",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023年7月,,Test Site,Test Journal
+No,"Test Empty Date",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,,,Test Site,Test Journal
+`;
+    
+    // 一時ファイルのパスを設定
+    const tempDir = path.join(__dirname, '../../temp');
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+    
+    const tempFilePath = path.join(tempDir, 'temp_dates.csv');
+    
+    // テスト前に一時ファイルが存在する場合は削除
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath);
+    }
+    
+    // 一時ファイルに書き込み
+    fs.writeFileSync(tempFilePath, testCsvData, 'utf8');
+    
+    try {
+      // 変換処理を実行
+      const jsonData = csvToJson(tempFilePath);
+      
+      // 4つのデータが正しく変換されていることを確認
+      expect(jsonData.length).toBe(4);
+      
+      // 日付範囲が正しく処理されていることを確認
+      expect(jsonData[0].date).toBe('2021年10月3日 → 2021年10月6日');
+      expect(jsonData[0].startDate).toBe('2021-10-03');
+      expect(jsonData[0].endDate).toBe('2021-10-06');
+      expect(jsonData[0].sortableDate).toBe('2021-10-03');
+      
+      // 単一の日付が正しく処理されていることを確認
+      expect(jsonData[1].date).toBe('2022年5月15日');
+      expect(jsonData[1].startDate).toBe('2022-05-15');
+      expect(jsonData[1].endDate).toBe('2022-05-15');
+      expect(jsonData[1].sortableDate).toBe('2022-05-15');
+      
+      // 年月のみの日付が正しく処理されていることを確認
+      expect(jsonData[2].date).toBe('2023年7月');
+      expect(jsonData[2].startDate).toBe('2023-07-01');
+      expect(jsonData[2].endDate).toBe('2023-07-01');
+      expect(jsonData[2].sortableDate).toBe('2023-07-01');
+      
+      // 空の日付が正しく処理されていることを確認
+      expect(jsonData[3].date).toBe('');
+      expect(jsonData[3].startDate).toBe('');
+      expect(jsonData[3].endDate).toBe('');
+      expect(jsonData[3].sortableDate).toBe('');
+    } finally {
+      // テスト後に一時ファイルを削除
+      if (fs.existsSync(tempFilePath)) {
+        fs.unlinkSync(tempFilePath);
+      }
+    }
+  });
 });

--- a/src/__tests__/csvToJson.test.js
+++ b/src/__tests__/csvToJson.test.js
@@ -128,4 +128,98 @@ No,,,,,,,,,,,,
       }
     }
   });
+  
+  test('handles comma-separated authorship correctly', () => {
+    // テスト内容: カンマで区切られた著者の役割が配列として処理されることを確認
+    
+    // テスト用のCSVデータを準備（カンマで区切られた著者の役割を含む）
+    const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
+No,"Test Author, ""Multiple Roles""",テスト,Test Type,Reviewed,"Corresponding author, Lead author",Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
+No,"Test Author, ""Single Role""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
+`;
+    
+    // 一時ファイルのパスを設定
+    const tempDir = path.join(__dirname, '../../temp');
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+    
+    const tempFilePath = path.join(tempDir, 'temp_authorship.csv');
+    
+    // テスト前に一時ファイルが存在する場合は削除
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath);
+    }
+    
+    // 一時ファイルに書き込み
+    fs.writeFileSync(tempFilePath, testCsvData, 'utf8');
+    
+    try {
+      // 変換処理を実行
+      const jsonData = csvToJson(tempFilePath);
+      
+      // 2つのデータが正しく変換されていることを確認
+      expect(jsonData.length).toBe(2);
+      
+      // カンマで区切られた著者の役割が配列として処理されていることを確認
+      expect(Array.isArray(jsonData[0].authorship)).toBe(true);
+      expect(jsonData[0].authorship).toEqual(['Corresponding author', 'Lead author']);
+      
+      // 単一の著者の役割は文字列として処理されていることを確認
+      expect(Array.isArray(jsonData[1].authorship)).toBe(false);
+      expect(jsonData[1].authorship).toBe('Lead author');
+    } finally {
+      // テスト後に一時ファイルを削除
+      if (fs.existsSync(tempFilePath)) {
+        fs.unlinkSync(tempFilePath);
+      }
+    }
+  });
+
+  test('handles comma-separated presentation types correctly', () => {
+    // テスト内容: カンマで区切られた発表タイプが配列として処理されることを確認
+    
+    // テスト用のCSVデータを準備（カンマで区切られた発表タイプを含む）
+    const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
+No,"Test Author, ""Multiple Types""",テスト,Test Type,Reviewed,Lead author,"Oral, Poster",,https://example.com,2023-01-01,,Test Site,Test Journal
+No,"Test Author, ""Single Type""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
+`;
+    
+    // 一時ファイルのパスを設定
+    const tempDir = path.join(__dirname, '../../temp');
+    if (!fs.existsSync(tempDir)) {
+      fs.mkdirSync(tempDir, { recursive: true });
+    }
+    
+    const tempFilePath = path.join(tempDir, 'temp_presentation_types.csv');
+    
+    // テスト前に一時ファイルが存在する場合は削除
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath);
+    }
+    
+    // 一時ファイルに書き込み
+    fs.writeFileSync(tempFilePath, testCsvData, 'utf8');
+    
+    try {
+      // 変換処理を実行
+      const jsonData = csvToJson(tempFilePath);
+      
+      // 2つのデータが正しく変換されていることを確認
+      expect(jsonData.length).toBe(2);
+      
+      // カンマで区切られた発表タイプが配列として処理されていることを確認
+      expect(Array.isArray(jsonData[0].presentationType)).toBe(true);
+      expect(jsonData[0].presentationType).toEqual(['Oral', 'Poster']);
+      
+      // 単一の発表タイプは文字列として処理されていることを確認
+      expect(Array.isArray(jsonData[1].presentationType)).toBe(false);
+      expect(jsonData[1].presentationType).toBe('Oral');
+    } finally {
+      // テスト後に一時ファイルを削除
+      if (fs.existsSync(tempFilePath)) {
+        fs.unlinkSync(tempFilePath);
+      }
+    }
+  });
 });

--- a/src/data/publications.json
+++ b/src/data/publications.json
@@ -155,7 +155,10 @@
     "japanese": "",
     "type": "Journal paper：原著論文",
     "review": "Reviewed",
-    "authorship": "Corresponding author, Lead author",
+    "authorship": [
+      "Corresponding author",
+      "Lead author"
+    ],
     "presentationType": "",
     "doi": "https://doi.org/10.1007/s10043-023-00810-2",
     "webLink": "",
@@ -231,7 +234,10 @@
     "type": "Research paper (international conference)：国際会議",
     "review": "Reviewed",
     "authorship": "Lead author",
-    "presentationType": "Oral, Poster",
+    "presentationType": [
+      "Oral",
+      "Poster"
+    ],
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000786",
     "date": "2024年3月1日 → 2024年3月2日",

--- a/src/data/publications.json
+++ b/src/data/publications.json
@@ -10,6 +10,9 @@
     "doi": "",
     "webLink": "https://www.isom.jp/PDF/ISOM21_Advance%20Program.pdf",
     "date": "2021年10月3日 → 2021年10月6日",
+    "startDate": "2021-10-03",
+    "endDate": "2021-10-06",
+    "sortableDate": "2021-10-03",
     "others": "",
     "site": "online",
     "journalConference": "ISOM21"
@@ -25,6 +28,9 @@
     "doi": "",
     "webLink": "https://www.ite.or.jp/ken/paper/202202210A94/",
     "date": "2022年2月21日",
+    "startDate": "2022-02-21",
+    "endDate": "2022-02-21",
+    "sortableDate": "2022-02-21",
     "others": "",
     "site": "online",
     "journalConference": "MMS2022"
@@ -40,6 +46,9 @@
     "doi": "",
     "webLink": "https://www.i-w-holography.org/archives/iwh2021-top/iwh2021-program/",
     "date": "2022年3月11日 → 2022年3月12日",
+    "startDate": "2022-03-11",
+    "endDate": "2022-03-12",
+    "sortableDate": "2022-03-11",
     "others": "",
     "site": "",
     "journalConference": "IWH2021"
@@ -55,6 +64,9 @@
     "doi": "",
     "webLink": "https://www.brain.kyutech.ac.jp/~neuro/2021/12/08/3rdsympo/?lang=en",
     "date": "2022年3月18日 → 2022年3月19日",
+    "startDate": "2022-03-18",
+    "endDate": "2022-03-19",
+    "sortableDate": "2022-03-18",
     "others": "",
     "site": "Premier Hotel Mojiko, Kitakyushu, Fukuoka, Japan",
     "journalConference": "the 3rd International Symposium on Neuromorphic AI Hardware"
@@ -70,6 +82,9 @@
     "doi": "",
     "webLink": "https://opg.optica.org/abstract.cfm?uri=ISISOM-2022-ITuPJ_01",
     "date": "2022年7月31日 → 2022年8月3日",
+    "startDate": "2022-07-31",
+    "endDate": "2022-08-03",
+    "sortableDate": "2022-07-31",
     "others": "",
     "site": "Sapporo Convention Center, Sapporo, Hokkaido, Japan",
     "journalConference": "ISOM2022"
@@ -85,6 +100,9 @@
     "doi": "",
     "webLink": "http://sigasd.ipsj.or.jp/?p=1574",
     "date": "2022年12月2日",
+    "startDate": "2022-12-02",
+    "endDate": "2022-12-02",
+    "sortableDate": "2022-12-02",
     "others": "",
     "site": "",
     "journalConference": "第25回ASD研究会"
@@ -100,6 +118,9 @@
     "doi": "",
     "webLink": "http://www.jswe.jp/division/kyushu/2022/entry.html",
     "date": "2022年12月10日",
+    "startDate": "2022-12-10",
+    "endDate": "2022-12-10",
+    "sortableDate": "2022-12-10",
     "others": "",
     "site": "",
     "journalConference": "第7回福祉工学会九州支部大会"
@@ -115,6 +136,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000113",
     "date": "2022年12月13日 → 2022年12月15日",
+    "startDate": "2022-12-13",
+    "endDate": "2022-12-15",
+    "sortableDate": "2022-12-13",
     "others": "",
     "site": "",
     "journalConference": "the 4th International Symposium on Neuromorphic AI Hardware"
@@ -130,6 +154,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000111",
     "date": "2022年12月13日 → 2022年12月15日",
+    "startDate": "2022-12-13",
+    "endDate": "2022-12-15",
+    "sortableDate": "2022-12-13",
     "others": "",
     "site": "ART HOTEL Kokura New Tagawa, Kitakyushu, Fukuoka, Japan",
     "journalConference": "the 4th International Symposium on Neuromorphic AI Hardware"
@@ -145,6 +172,9 @@
     "doi": "",
     "webLink": "https://npip.ed.kyushu-u.ac.jp/pdf/2nd_optneuro_flyer_v3_1.pdf",
     "date": "2023年3月13日 → 2023年3月14日",
+    "startDate": "2023-03-13",
+    "endDate": "2023-03-14",
+    "sortableDate": "2023-03-13",
     "others": "",
     "site": "九州大学伊都ゲストハウス 多目的ホール, Fukuoka, Japan",
     "journalConference": "第２回光ニューロワークショップ"
@@ -163,6 +193,9 @@
     "doi": "https://doi.org/10.1007/s10043-023-00810-2",
     "webLink": "",
     "date": "2023年4月28日",
+    "startDate": "2023-04-28",
+    "endDate": "2023-04-28",
+    "sortableDate": "2023-04-28",
     "others": "SharedIt link (full text, view only): https://rdcu.be/daZfo",
     "site": "",
     "journalConference": "Optical Review"
@@ -178,6 +211,9 @@
     "doi": "",
     "webLink": "https://www.i-photonics.jp/meetings/meetings2023.html#20230721SGSIPG",
     "date": "2023年7月21日",
+    "startDate": "2023-07-21",
+    "endDate": "2023-07-21",
+    "sortableDate": "2023-07-21",
     "others": "",
     "site": "東京工業大学大岡山キャンパス　西9号館1階　コラボレーションルーム, Tokyo, Japan",
     "journalConference": "情報フォトニクス研究討論会2023"
@@ -193,6 +229,9 @@
     "doi": "",
     "webLink": "https://www.photoniccomputing.jp/activities/2023_08_07_region_meeting_online.php",
     "date": "2023年8月7日 → 2023年8月8日",
+    "startDate": "2023-08-07",
+    "endDate": "2023-08-08",
+    "sortableDate": "2023-08-07",
     "others": "",
     "site": "東京大学工学部６号館３階セミナー室A・D・B・C, Tokyo, Japan",
     "journalConference": "光の極限性能を生かすフォトニックコンピューティング 第三回領域会議"
@@ -208,6 +247,9 @@
     "doi": "",
     "webLink": "https://www.i-photonics.jp/dhip2023/index.html#",
     "date": "2023年12月18日 → 2023年12月20日",
+    "startDate": "2023-12-18",
+    "endDate": "2023-12-20",
+    "sortableDate": "2023-12-18",
     "others": "",
     "site": "B-con Plaza, Beppu, Oita, Japan",
     "journalConference": "DHIP2023"
@@ -223,6 +265,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000785",
     "date": "2024年3月1日 → 2024年3月2日",
+    "startDate": "2024-03-01",
+    "endDate": "2024-03-02",
+    "sortableDate": "2024-03-01",
     "others": "",
     "site": "",
     "journalConference": "the 5th International Symposium on Neuromorphic AI Hardware"
@@ -241,6 +286,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000786",
     "date": "2024年3月1日 → 2024年3月2日",
+    "startDate": "2024-03-01",
+    "endDate": "2024-03-02",
+    "sortableDate": "2024-03-01",
     "others": "",
     "site": "RIHGA Royal Hotel Kokura, Kitakyushu, Fukuoka, Japan",
     "journalConference": "the 5th International Symposium on Neuromorphic AI Hardware"
@@ -256,6 +304,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2000826",
     "date": "2024年3月10日",
+    "startDate": "2024-03-10",
+    "endDate": "2024-03-10",
+    "sortableDate": "2024-03-10",
     "others": "",
     "site": "",
     "journalConference": "Photonics NEWS"
@@ -271,6 +322,9 @@
     "doi": "",
     "webLink": "https://www.photoniccomputing.jp/activities/2024_03_11_symposium_session3.php",
     "date": "2024年3月11日 → 2024年3月12日",
+    "startDate": "2024-03-11",
+    "endDate": "2024-03-12",
+    "sortableDate": "2024-03-11",
     "others": "",
     "site": "Ito Hall, Ito International Research Center, the University of Tokyo, Tokyo, Japan",
     "journalConference": "The First International Symposium on Photonic Computing"
@@ -286,6 +340,9 @@
     "doi": "",
     "webLink": "https://www.brain.kyutech.ac.jp/~neuro/2024/03/30/materials-meet-robots-2024/?lang=en",
     "date": "2024年5月7日 → 2024年5月8日",
+    "startDate": "2024-05-07",
+    "endDate": "2024-05-08",
+    "sortableDate": "2024-05-07",
     "others": "",
     "site": "Conference Center of Kitakyushu Science and Research Park, Kitakyushu, Fukuoka, Japan",
     "journalConference": "Materials Meet Robots 2024"
@@ -301,6 +358,9 @@
     "doi": "",
     "webLink": "https://kyutech.repo.nii.ac.jp/records/2001193",
     "date": "2024年7月10日 → 2024年7月12日",
+    "startDate": "2024-07-10",
+    "endDate": "2024-07-12",
+    "sortableDate": "2024-07-10",
     "others": "",
     "site": "",
     "journalConference": "ODF2024"
@@ -316,6 +376,9 @@
     "doi": "",
     "webLink": "https://scholar.google.co.jp/citations?view_op=view_citation&hl=ja&user=15WrAiYAAAAJ&authuser=1&citation_for_view=15WrAiYAAAAJ:Y0pCki6q_DkC",
     "date": "2024年7月10日 → 2024年7月12日",
+    "startDate": "2024-07-10",
+    "endDate": "2024-07-12",
+    "sortableDate": "2024-07-10",
     "others": "",
     "site": "University of Arizona, Tucson, Arizona, USA",
     "journalConference": "ODF2024"
@@ -331,6 +394,9 @@
     "doi": "",
     "webLink": "https://isom.jp/PDF/FInal_Presentation_List_in_ISOM24.pdf",
     "date": "2024年10月20日 → 2024年10月23日",
+    "startDate": "2024-10-20",
+    "endDate": "2024-10-23",
+    "sortableDate": "2024-10-20",
     "others": "",
     "site": "",
     "journalConference": "ISOM2024"
@@ -346,6 +412,9 @@
     "doi": "",
     "webLink": "https://isom.jp/PDF/FInal_Presentation_List_in_ISOM24.pdf",
     "date": "2024年10月20日 → 2024年10月23日",
+    "startDate": "2024-10-20",
+    "endDate": "2024-10-23",
+    "sortableDate": "2024-10-20",
     "others": "",
     "site": "",
     "journalConference": "ISOM2024"
@@ -361,6 +430,9 @@
     "doi": "",
     "webLink": "https://www.ite.or.jp/ken/paper/20241205vAN8/",
     "date": "2024年12月5日",
+    "startDate": "2024-12-05",
+    "endDate": "2024-12-05",
+    "sortableDate": "2024-12-05",
     "others": "",
     "site": "",
     "journalConference": "MMS2024(愛媛)"
@@ -376,6 +448,9 @@
     "doi": "",
     "webLink": "https://www.i-w-holography.org/",
     "date": "2024年12月10日 → 2024年12月12日",
+    "startDate": "2024-12-10",
+    "endDate": "2024-12-12",
+    "sortableDate": "2024-12-10",
     "others": "",
     "site": "Ala Moana Hotel, Honolulu, Hawaii, USA",
     "journalConference": "IWH2024"
@@ -391,6 +466,9 @@
     "doi": "",
     "webLink": "https://www.photoniccomputing.jp/activities/2024_12_17_symposium_session.php",
     "date": "2024年12月17日",
+    "startDate": "2024-12-17",
+    "endDate": "2024-12-17",
+    "sortableDate": "2024-12-17",
     "others": "",
     "site": "国立研究開発法人 情報通信研究機構 本部 ３号館１階 セミナー室前 展示スペース（東京都小金井市）",
     "journalConference": "「光の極限性能を生かすフォトニックコンピューティングの創成」第2回公開シンポジウム"
@@ -406,6 +484,9 @@
     "doi": "",
     "webLink": "https://www.ite.or.jp/ken/paper/20250219kANt/",
     "date": "2025年2月19日",
+    "startDate": "2025-02-19",
+    "endDate": "2025-02-19",
+    "sortableDate": "2025-02-19",
     "others": "",
     "site": "",
     "journalConference": "MMS2024(北海道)"
@@ -421,6 +502,9 @@
     "doi": "",
     "webLink": "",
     "date": "2025年3月3日 → 2025年3月4日",
+    "startDate": "2025-03-03",
+    "endDate": "2025-03-04",
+    "sortableDate": "2025-03-03",
     "others": "",
     "site": "Kitakyushu, Fukuoka, Japan",
     "journalConference": "the 6th International Symposium on Neuromorphic AI Hardware"

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -52,7 +52,10 @@ function Publications() {
         review: pub.review,
         authorship: pub.authorship,
         presentationType: pub.presentationType,
-        others: pub.others
+        others: pub.others,
+        startDate: pub.startDate,
+        endDate: pub.endDate,
+        sortableDate: pub.sortableDate
       };
     });
   }, []);
@@ -60,8 +63,12 @@ function Publications() {
   // 並び順に基づいて出版物を並べ替え
   const sortedPublications = useMemo(() => {
     if (sortOrder === 'chronological') {
-      // 時系列順（新しい順）
+      // 時系列順（新しい順）- 開始日に基づくソート
       return [...formattedPublications].sort((a, b) => {
+        // sortableDateが存在する場合はそれを使用、存在しない場合は年を使用
+        if (a.sortableDate && b.sortableDate) {
+          return a.sortableDate > b.sortableDate ? -1 : a.sortableDate < b.sortableDate ? 1 : 0;
+        }
         return (b.year || 0) - (a.year || 0);
       });
     } else {
@@ -75,7 +82,10 @@ function Publications() {
           return typeIndexA - typeIndexB;
         }
         
-        // 同じ種類の場合は年の新しい順
+        // 同じ種類の場合は開始日の新しい順
+        if (a.sortableDate && b.sortableDate) {
+          return a.sortableDate > b.sortableDate ? -1 : a.sortableDate < b.sortableDate ? 1 : 0;
+        }
         return (b.year || 0) - (a.year || 0);
       });
     }
@@ -537,7 +547,32 @@ function Publications() {
                   {/* 三行目: ジャーナル名 */}
                   <div style={{ marginTop: "0.5rem" }}>{pub.journal}</div>
                   
-                  {/* 四行目以降: DOI、URL、Others */}
+                  {/* 四行目: 開始日、終了日、場所 */}
+                  {(pub.startDate || pub.site) && (
+                    <div style={{ marginTop: "0.25rem", fontSize: "0.9rem", color: "#555" }}>
+                      {/* 開始日と終了日が同じ場合は開始日のみ表示 */}
+                      {pub.startDate && (
+                        <>
+                          {language === 'ja' ? '日付: ' : 'Date: '}
+                          {pub.startDate === pub.endDate ?
+                            pub.startDate :
+                            `${pub.startDate} → ${pub.endDate}`
+                          }
+                        </>
+                      )}
+                      
+                      {/* 場所がある場合は表示 */}
+                      {pub.site && (
+                        <>
+                          {pub.startDate && <span style={{ margin: "0 0.5rem" }}>|</span>}
+                          {language === 'ja' ? '場所: ' : 'Location: '}
+                          {pub.site}
+                        </>
+                      )}
+                    </div>
+                  )}
+                  
+                  {/* 五行目以降: DOI、URL、Others */}
                   {pub.doi && (
                     <div style={{ marginTop: "0.25rem" }}>
                       DOI: <a href={`https://doi.org/${pub.doi}`} target="_blank" rel="noopener noreferrer">

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -95,8 +95,18 @@ function Publications() {
       if (pub.year && !options.year.includes(pub.year.toString())) {
         options.year.push(pub.year.toString());
       }
-      if (pub.authorship && !options.authorship.includes(pub.authorship)) {
-        options.authorship.push(pub.authorship);
+      
+      // authorshipが配列の場合は各要素を個別に処理
+      if (pub.authorship) {
+        if (Array.isArray(pub.authorship)) {
+          pub.authorship.forEach(role => {
+            if (!options.authorship.includes(role)) {
+              options.authorship.push(role);
+            }
+          });
+        } else if (!options.authorship.includes(pub.authorship)) {
+          options.authorship.push(pub.authorship);
+        }
       }
       if (pub.type && !options.type.includes(pub.type)) {
         options.type.push(pub.type);
@@ -104,8 +114,17 @@ function Publications() {
       if (pub.review && !options.review.includes(pub.review)) {
         options.review.push(pub.review);
       }
-      if (pub.presentationType && !options.presentationType.includes(pub.presentationType)) {
-        options.presentationType.push(pub.presentationType);
+      // presentationTypeが配列の場合は各要素を個別に処理
+      if (pub.presentationType) {
+        if (Array.isArray(pub.presentationType)) {
+          pub.presentationType.forEach(type => {
+            if (!options.presentationType.includes(type)) {
+              options.presentationType.push(type);
+            }
+          });
+        } else if (!options.presentationType.includes(pub.presentationType)) {
+          options.presentationType.push(pub.presentationType);
+        }
       }
     });
     
@@ -121,8 +140,21 @@ function Publications() {
       }
       
       // 著者の役割フィルター
-      if (selectedFilters.authorship.length > 0 && !selectedFilters.authorship.includes(pub.authorship)) {
-        return false;
+      if (selectedFilters.authorship.length > 0) {
+        // authorshipが配列の場合
+        if (Array.isArray(pub.authorship)) {
+          // 選択されたフィルターのいずれかが配列内に存在するかチェック
+          const hasMatchingRole = pub.authorship.some(role =>
+            selectedFilters.authorship.includes(role)
+          );
+          if (!hasMatchingRole) {
+            return false;
+          }
+        }
+        // authorshipが文字列の場合
+        else if (!selectedFilters.authorship.includes(pub.authorship)) {
+          return false;
+        }
       }
       
       // タイプフィルター
@@ -136,8 +168,21 @@ function Publications() {
       }
       
       // 発表タイプフィルター
-      if (selectedFilters.presentationType.length > 0 && !selectedFilters.presentationType.includes(pub.presentationType)) {
-        return false;
+      if (selectedFilters.presentationType.length > 0) {
+        // presentationTypeが配列の場合
+        if (Array.isArray(pub.presentationType)) {
+          // 選択されたフィルターのいずれかが配列内に存在するかチェック
+          const hasMatchingType = pub.presentationType.some(type =>
+            selectedFilters.presentationType.includes(type)
+          );
+          if (!hasMatchingType) {
+            return false;
+          }
+        }
+        // presentationTypeが文字列の場合
+        else if (!selectedFilters.presentationType.includes(pub.presentationType)) {
+          return false;
+        }
       }
       
       return true;
@@ -436,9 +481,25 @@ function Publications() {
                       </span>
                     )}
                     {pub.authorship && (
-                      <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
-                        {pub.authorship}
-                      </span>
+                      <>
+                        {Array.isArray(pub.authorship) ? (
+                          // 配列の場合は各要素を個別のタグとして表示
+                          pub.authorship.map((role, index) => (
+                            <span
+                              key={`${pub.id}-role-${index}`}
+                              className="tag"
+                              style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem", marginRight: "0.5rem" }}
+                            >
+                              {role}
+                            </span>
+                          ))
+                        ) : (
+                          // 文字列の場合は単一のタグとして表示
+                          <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
+                            {pub.authorship}
+                          </span>
+                        )}
+                      </>
                     )}
                     {pub.type && (
                       <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
@@ -451,9 +512,25 @@ function Publications() {
                       </span>
                     )}
                     {pub.presentationType && (
-                      <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
-                        {pub.presentationType}
-                      </span>
+                      <>
+                        {Array.isArray(pub.presentationType) ? (
+                          // 配列の場合は各要素を個別のタグとして表示
+                          pub.presentationType.map((type, index) => (
+                            <span
+                              key={`${pub.id}-type-${index}`}
+                              className="tag"
+                              style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem", marginRight: "0.5rem" }}
+                            >
+                              {type}
+                            </span>
+                          ))
+                        ) : (
+                          // 文字列の場合は単一のタグとして表示
+                          <span className="tag" style={{ backgroundColor: "#f0f0f0", padding: "0.2rem 0.5rem", borderRadius: "0.25rem", fontSize: "0.85rem" }}>
+                            {pub.presentationType}
+                          </span>
+                        )}
+                      </>
                     )}
                   </div>
                   

--- a/src/utils/csvToJson.js
+++ b/src/utils/csvToJson.js
@@ -41,14 +41,25 @@ function csvToJson(csvFilePath) {
       // 各値をヘッダーと対応させてオブジェクトを作成
       const obj = {};
       
+      // カンマで区切られた値を配列に変換する関数
+      const processCommaSeparatedValue = (value) => {
+        const trimmedValue = (value || '').trim();
+        if (trimmedValue.includes(',')) {
+          return trimmedValue.split(',').map(item => item.trim());
+        }
+        return trimmedValue;
+      };
+      
       // 各列の値をマッピング（値が存在する場合のみtrim()を適用）
       obj.hasEmptyFields = (values[0] || '').trim() === 'Yes';
       obj.name = (values[1] || '').trim();
       obj.japanese = (values[2] || '').trim();
       obj.type = (values[3] || '').trim();
       obj.review = (values[4] || '').trim();
-      obj.authorship = (values[5] || '').trim();
-      obj.presentationType = (values[6] || '').trim();
+      
+      // カンマで区切られる可能性のあるフィールドは配列に変換
+      obj.authorship = processCommaSeparatedValue(values[5]);
+      obj.presentationType = processCommaSeparatedValue(values[6]);
       obj.doi = (values[7] || '').trim();
       obj.webLink = (values[8] || '').trim();
       obj.date = (values[9] || '').trim();

--- a/src/utils/csvToJson.js
+++ b/src/utils/csvToJson.js
@@ -50,6 +50,60 @@ function csvToJson(csvFilePath) {
         return trimmedValue;
       };
       
+      // 日付を開始日と終了日に分割し、ソート可能な形式に変換する関数
+      const processDate = (dateString) => {
+        if (!dateString) return { startDate: '', endDate: '', sortableDate: '' };
+        
+        // 日付が「2021年10月3日 → 2021年10月6日」のような形式かチェック
+        const dateRangeMatch = dateString.match(/(\d{4})年(\d{1,2})月(\d{1,2})日(?:\s*→\s*(\d{4})年(\d{1,2})月(\d{1,2})日)?/);
+        
+        if (dateRangeMatch) {
+          // 開始日を取得
+          const startYear = dateRangeMatch[1];
+          const startMonth = dateRangeMatch[2].padStart(2, '0');
+          const startDay = dateRangeMatch[3].padStart(2, '0');
+          const startDate = `${startYear}-${startMonth}-${startDay}`;
+          
+          // 終了日を取得（存在する場合）
+          let endDate = '';
+          if (dateRangeMatch[4]) {
+            const endYear = dateRangeMatch[4];
+            const endMonth = dateRangeMatch[5].padStart(2, '0');
+            const endDay = dateRangeMatch[6].padStart(2, '0');
+            endDate = `${endYear}-${endMonth}-${endDay}`;
+          } else {
+            endDate = startDate; // 終了日がない場合は開始日と同じ
+          }
+          
+          return {
+            startDate,
+            endDate,
+            sortableDate: startDate // ソート用の日付は開始日を使用
+          };
+        }
+        
+        // 「2021年10月」のような年月のみの形式をチェック
+        const yearMonthMatch = dateString.match(/(\d{4})年(\d{1,2})月/);
+        if (yearMonthMatch) {
+          const year = yearMonthMatch[1];
+          const month = yearMonthMatch[2].padStart(2, '0');
+          const date = `${year}-${month}-01`; // 日付は1日とする
+          
+          return {
+            startDate: date,
+            endDate: date,
+            sortableDate: date
+          };
+        }
+        
+        // その他の形式の場合はそのまま返す
+        return {
+          startDate: dateString,
+          endDate: dateString,
+          sortableDate: dateString
+        };
+      };
+      
       // 各列の値をマッピング（値が存在する場合のみtrim()を適用）
       obj.hasEmptyFields = (values[0] || '').trim() === 'Yes';
       obj.name = (values[1] || '').trim();
@@ -62,7 +116,15 @@ function csvToJson(csvFilePath) {
       obj.presentationType = processCommaSeparatedValue(values[6]);
       obj.doi = (values[7] || '').trim();
       obj.webLink = (values[8] || '').trim();
-      obj.date = (values[9] || '').trim();
+      
+      // 日付を処理
+      const dateValue = (values[9] || '').trim();
+      const processedDate = processDate(dateValue);
+      obj.date = dateValue; // 元の日付文字列も保持
+      obj.startDate = processedDate.startDate;
+      obj.endDate = processedDate.endDate;
+      obj.sortableDate = processedDate.sortableDate;
+      
       obj.others = (values[10] || '').trim();
       obj.site = (values[11] || '').trim();
       obj.journalConference = (values[12] || '').trim();


### PR DESCRIPTION
## 概要
Publicationページにおける日付処理を改善し、以下の機能を実装しました：
1. CSVデータの日付を開始日と終了日に分割し、ソート機能で利用可能な形式で格納
2. 時系列順のソートを年ベースから開始日ベースに変更し、より正確なソートを実現
3. 出版物の詳細表示に開始日、終了日、場所の情報を追加（学会名の下、URLの上に表示）

## 変更内容

### 機能追加・改善
1. 日付処理の改善
   - 「2021年10月3日 → 2021年10月6日」のような日付範囲を開始日と終了日に分割
   - 「2022年5月15日」のような単一日付も同様に処理
   - 「2023年7月」のような年月のみの形式にも対応（月の1日として処理）
   - すべての日付を「YYYY-MM-DD」形式に変換し、ソートしやすい形式で保存

2. ソート機能の改善
   - 時系列順（chronological）のソートを年（year）ベースから開始日（sortableDate）ベースに変更
   - 種類順（type）でも、同じ種類の場合は開始日に基づいてソートするように変更
   - これにより、複数日にわたるイベントも正確にソートされるようになった

3. 表示機能の追加
   - 学会名の下、URLの上に開始日、終了日、場所の情報を表示
   - 開始日と終了日が同じ場合は開始日のみを表示
   - 場所（site）がある場合は、日付の後に区切り記号（|）を入れて表示
   - 言語設定に応じて、「日付:」「場所:」のラベルを日本語または英語で表示

### 技術的な実装詳細

1. csvToJson.js の修正
   ```javascript
   // 日付を開始日と終了日に分割し、ソート可能な形式に変換する関数
   const processDate = (dateString) => {
     if (!dateString) return { startDate: '', endDate: '', sortableDate: '' };
     
     // 日付が「2021年10月3日 → 2021年10月6日」のような形式かチェック
     const dateRangeMatch = dateString.match(/(\d{4})年(\d{1,2})月(\d{1,2})日(?:\s*→\s*(\d{4})年(\d{1,2})月(\d{1,2})日)?/);
     
     if (dateRangeMatch) {
       // 開始日を取得
       const startYear = dateRangeMatch[1];
       const startMonth = dateRangeMatch[2].padStart(2, '0');
       const startDay = dateRangeMatch[3].padStart(2, '0');
       const startDate = `${startYear}-${startMonth}-${startDay}`;
       
       // 終了日を取得（存在する場合）
       let endDate = '';
       if (dateRangeMatch[4]) {
         const endYear = dateRangeMatch[4];
         const endMonth = dateRangeMatch[5].padStart(2, '0');
         const endDay = dateRangeMatch[6].padStart(2, '0');
         endDate = `${endYear}-${endMonth}-${endDay}`;
       } else {
         endDate = startDate; // 終了日がない場合は開始日と同じ
       }
       
       return {
         startDate,
         endDate,
         sortableDate: startDate // ソート用の日付は開始日を使用
       };
     }
     
     // 「2021年10月」のような年月のみの形式をチェック
     const yearMonthMatch = dateString.match(/(\d{4})年(\d{1,2})月/);
     if (yearMonthMatch) {
       const year = yearMonthMatch[1];
       const month = yearMonthMatch[2].padStart(2, '0');
       const date = `${year}-${month}-01`; // 日付は1日とする
       
       return {
         startDate: date,
         endDate: date,
         sortableDate: date
       };
     }
     
     // その他の形式の場合はそのまま返す
     return {
       startDate: dateString,
       endDate: dateString,
       sortableDate: dateString
     };
   };
   
   // 日付を処理
   const dateValue = (values[9] || '').trim();
   const processedDate = processDate(dateValue);
   obj.date = dateValue; // 元の日付文字列も保持
   obj.startDate = processedDate.startDate;
   obj.endDate = processedDate.endDate;
   obj.sortableDate = processedDate.sortableDate;
   ```

2. Publications.jsx の修正（ソート機能）
   ```javascript
   // formattedPublications に startDate, endDate, sortableDate プロパティを追加
   const formattedPublications = useMemo(() => {
     return publicationsData.map((pub, index) => {
       // ...
       return {
         // ...
         startDate: pub.startDate,
         endDate: pub.endDate,
         sortableDate: pub.sortableDate
       };
     });
   }, []);

   // 時系列順のソートを開始日ベースに変更
   if (sortOrder === 'chronological') {
     // 時系列順（新しい順）- 開始日に基づくソート
     return [...formattedPublications].sort((a, b) => {
       // sortableDateが存在する場合はそれを使用、存在しない場合は年を使用
       if (a.sortableDate && b.sortableDate) {
         return a.sortableDate > b.sortableDate ? -1 : a.sortableDate < b.sortableDate ? 1 : 0;
       }
       return (b.year || 0) - (a.year || 0);
     });
   }
   ```

3. Publications.jsx の修正（表示機能）
   ```jsx
   {/* 四行目: 開始日、終了日、場所 */}
   {(pub.startDate || pub.site) && (
     <div style={{ marginTop: "0.25rem", fontSize: "0.9rem", color: "#555" }}>
       {/* 開始日と終了日が同じ場合は開始日のみ表示 */}
       {pub.startDate && (
         <>
           {language === 'ja' ? '日付: ' : 'Date: '}
           {pub.startDate === pub.endDate ? 
             pub.startDate : 
             `${pub.startDate} → ${pub.endDate}`
           }
         </>
       )}
       
       {/* 場所がある場合は表示 */}
       {pub.site && (
         <>
           {pub.startDate && <span style={{ margin: "0 0.5rem" }}>|</span>}
           {language === 'ja' ? '場所: ' : 'Location: '}
           {pub.site}
         </>
       )}
     </div>
   )}
   ```

## テスト

### 単体テスト
1. csvToJson.test.js に日付処理のテストを追加
   - 日付範囲（「2021年10月3日 → 2021年10月6日」）が正しく分割されることを確認
   - 単一日付（「2022年5月15日」）が正しく処理されることを確認
   - 年月のみの形式（「2023年7月」）が正しく処理されることを確認
   - 空の日付が正しく処理されることを確認

2. Publications.test.jsx に開始日に基づくソートのテストを追加
   - 出版物が開始日の降順（新しい順）でソートされることを確認

### 手動テスト
1. 開発サーバーを起動し、Publicationページを表示
2. 時系列順（年順）に切り替えて、出版物が開始日の降順で正しくソートされることを確認
3. 各出版物の詳細に開始日、終了日、場所が正しく表示されることを確認
4. 言語を切り替えて、ラベルが正しく表示されることを確認

すべてのテストが正常にパスし、機能が正しく動作することを確認しました。