### PR TITLE
プロフィール・連絡先・所属学会情報を更新

### DIFF
--- a/public/markdown/en/home.md
+++ b/public/markdown/en/home.md
@@ -1,15 +1,16 @@
 ### Affiliation
-- Assistant Professor, [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/), [Faculty of Engineering](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/)
+- Assistant Professor, [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/),  
+  [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/) ([Researcher Information](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en))
 - [Bunsen Lab. (Photonics Lab.)](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
 
 
 ### Contact
 
-- Mail: tomioka.rio288（at）gmail.com 
+- tomioka.rio（at）fukuoka-u.ac.jp
+- tomioka.rio288（at）gmail.com
 
 Please change the (at) to @.  
-tomioka.rio288（at）mail.kyutech.jp became unavailable on 2026/3/31.  
-I will update my Fukuoka University email address once it is issued.
+tomioka.rio288（at）mail.kyutech.jp has been unavailable since 2026/3/31.
 
 ### Accounts
 - GitHub: [@tomiokario](https://github.com/tomiokario)

--- a/public/markdown/en/profilecv.md
+++ b/public/markdown/en/profilecv.md
@@ -6,7 +6,12 @@
 ### Career
 - April 2023 - March 2024: Kyutech Research Fellow (3rd generation)
 - April 2024 - March 2026: Kyushu Institute of Technology SPRING Scholarship Awardee
-- April 2026 - Present: Assistant Professor, Department of Electronics Engineering and Computer Science, Faculty of Engineering, Fukuoka University
+- April 2026 - Present: Assistant Professor, [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/),  
+  [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/) ([Researcher Information](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en))
+
+### Academic Societies
+- [The Optical Society of Japan](https://myosj.or.jp/)（日本光学会）
+- [The Institute of Image Information and Television Engineers](https://www.ite.or.jp/)（映像情報メディア学会）
 
 ### Awards and honors
 - The Institute of Image Information and Television Engineers [第25回・2022年度](https://www.ite.or.jp/contents/awards/yushukenkyu.html) [優秀研究発表賞](https://www.ite.or.jp/content/awards/)（2022/12/22）

--- a/public/markdown/ja/home.md
+++ b/public/markdown/ja/home.md
@@ -1,15 +1,15 @@
 ### 所属
-- [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/) 助教
+- [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/) 助教（[福岡大学研究者情報](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja)）
 - [文仙研究室（フォトニクス研究室）](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
 
 
 ### 連絡先
 
-- Mail: tomioka.rio288（at）gmail.com 
+- tomioka.rio（at）fukuoka-u.ac.jp
+- tomioka.rio288（at）gmail.com
 
 (at) を @ に変更してください。  
-tomioka.rio288（at）mail.kyutech.jp は 2026/3/31 で利用できなくなりました。  
-福岡大学のメールアドレスは発行され次第更新します。
+tomioka.rio288（at）mail.kyutech.jp は 2026/3/31 より利用できなくなりました。
 
 ### アカウント
 - GitHub: [@tomiokario](https://github.com/tomiokario)

--- a/public/markdown/ja/profilecv.md
+++ b/public/markdown/ja/profilecv.md
@@ -9,7 +9,11 @@
 ### 経歴
 - 2023.4 - 2024.3：[先端研究フェロー](https://www.ccr.kyutech.ac.jp/dc_support/fellowship/) 第三期生 ([2023年度採用](https://www.ccr.kyutech.ac.jp/dc_support/fellowship/recruiter.php))
 - 2024.4 - 2026.3：[九州工業大学SPRINGスカラシップ研究学生](https://www.ccr.kyutech.ac.jp/dc_support/spring)
-- 2026.4 - 現在：福岡大学 工学部 電子情報工学科 助教
+- 2026.4 - 現在：[福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/) 助教（[福岡大学研究者情報](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja)）
+
+### 所属学会
+- [日本光学会](https://myosj.or.jp/)（The Optical Society of Japan）
+- [映像情報メディア学会](https://www.ite.or.jp/)（The institute of image information and television engineers）
 
 ### 学術関係受賞
 映像情報メディア学会 [第25回・2022年度](https://www.ite.or.jp/contents/awards/yushukenkyu.html) [優秀研究発表賞](https://www.ite.or.jp/content/awards/)（2022年12月22日 受賞）


### PR DESCRIPTION
## Summary
- 福岡大学の助教就任に伴い、所属にリンクと研究者情報を追加（ja/en）
- 福岡大学メールアドレスを追加し、連絡先の表示順を更新（福大メールを先頭に）
- profilecv に所属学会セクションを追加（日本光学会・映像情報メディア学会）
- 英語版のリンクURLを英語ページ（`/english/...`）に変更

## Test plan
- [ ] Home（ja/en）の所属・連絡先の表示確認
- [ ] Profile（ja/en）の経歴・所属学会の表示確認
- [ ] 各リンクが正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)