### PR TITLE
researchmapツールをprivate submoduleへ分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # env
 .env
+
+# local generated artifacts
+tmp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/researchmap-private"]
+	path = tools/researchmap-private
+	url = git@github.com:tomiokario/my-web-page-to-research-map.git


### PR DESCRIPTION
## 概要
- researchmap 関連ツールを private リポジトリの submodule として分離
- public リポジトリ側では submodule 参照のみを保持
- 生成物の誤コミットを防ぐため `tmp/` を ignore に追加

## 変更内容
- `.gitmodules` に `tools/researchmap-private` を追加
- `tools/researchmap-private` で private repo `my-web-page-to-research-map` を参照
- `.gitignore` に `tmp/` を追加

## 確認事項
- public 側のブランチ履歴から researchmap 実装本体は外してあります
- private repo 側で researchmap ツール本体を管理します
