### PR TITLE
[codex] canonical fields 本線に寄せて legacy compatibility を整理

### DIFF
--- a/docs/admin/publications-management.md
+++ b/docs/admin/publications-management.md
@@ -76,7 +76,9 @@ flowchart LR
 - 通常運用の本線は `researchmap export JSONL -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - 逆向きの `publication_master.json -> researchmap` は、researchmap へ安全に再投入したいときだけ使う補助ツールです
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 側の情報を壊しにくくし、生成結果の由来や整合を確認するための補助です
-- `CSV -> master` の移行経路、`Publication` 風データ互換、旧 `researchmapFields` 互換は legacy / 補助経路であり、日常運用の中心ではありません
+- `CSV -> master` の移行経路は残しますが、日常運用の中心ではない移行専用の補助です
+- `Publication` 風データ互換は reversible sidecar や比較確認の補助に限り、`publication_master.json` の正本は canonical `fields` です
+- 旧 `researchmapFields` 形式の master は受け付けません
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモで、`publication_master.json` 自体は public 側の tracked canonical data として扱います
 
 ## master data の構造

--- a/scripts/importPublicationMasterFromCsv.ts
+++ b/scripts/importPublicationMasterFromCsv.ts
@@ -1,5 +1,5 @@
 /**
- * publication_data.csv から publication_master.json を生成する移行用スクリプト
+ * publication_data.csv から canonical な publication_master.json を生成する移行用スクリプト
  *
  * 使用方法:
  * npm run import-publications-csv

--- a/src/__tests__/csvToJson.test.ts
+++ b/src/__tests__/csvToJson.test.ts
@@ -1,275 +1,157 @@
 /**
- * CSVからJSONへの変換機能のテスト
- *
- * このテストファイルでは、出版物データのCSVファイルをJSON形式に変換する機能をテストします。
- * csvToJsonユーティリティは、カンマ区切りのCSVデータを解析し、Webアプリケーションで
- * 使用可能な構造化されたJSONオブジェクトの配列に変換します。
- * このテストでは、変換の正確性、エラー処理、特殊ケース（引用符内のカンマ、空行など）の
- * 適切な処理を検証します。
- *
- * テスト内容：
- * 1. csvToJson関数が存在し、正しく動作することの確認
- * 2. 実際のCSVファイルが存在し、アクセス可能であることの確認
- * 3. CSVデータが正確にJSON形式に変換され、必要なプロパティを含むことの確認
- * 4. 空行や不正な形式の行が適切に処理され、有効なデータのみが変換されることの確認
- * 5. 日本語などの多言語データが正しく処理されることの確認
+ * CSV から canonical publication master への移行テスト
  */
 
-const fs = require('fs');
-const path = require('path');
-const { csvToJson, importMasterFromCsvAndSave } = require('../utils/csvToJson');
+const fs = require("fs");
+const path = require("path");
+const { csvToMasterData, importMasterFromCsvAndSave } = require("../utils/csvToJson");
 
-// テストデータのパス (dataディレクトリがsrc配下に移動したためパスを更新)
-const CSV_FILE_PATH = path.join(__dirname, '../data/publication_data.csv');
+const CSV_FILE_PATH = path.join(__dirname, "../data/publication_data.csv");
 
-// ヘルパー関数: 一時ファイルの作成
-function createTempCsvFile(content: string, filename = 'temp_test.csv') {
-  const tempDir = path.join(__dirname, '../../temp');
+function createTempCsvFile(content: string, filename = "temp_test.csv") {
+  const tempDir = path.join(__dirname, "../../temp");
   if (!fs.existsSync(tempDir)) {
     fs.mkdirSync(tempDir, { recursive: true });
   }
-  
+
   const tempFilePath = path.join(tempDir, filename);
   if (fs.existsSync(tempFilePath)) {
     fs.unlinkSync(tempFilePath);
   }
-  
-  fs.writeFileSync(tempFilePath, content, 'utf8');
+
+  fs.writeFileSync(tempFilePath, content, "utf8");
   return tempFilePath;
 }
 
-// ヘルパー関数: 一時ファイルの削除
 function removeTempFile(filePath: string) {
   if (fs.existsSync(filePath)) {
     fs.unlinkSync(filePath);
   }
 }
 
-function parseCsvLineForTest(line: string) {
-  const result: string[] = [];
-  let current = '';
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-
-    if (char === '"') {
-      if (line[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-      continue;
-    }
-
-    if (char === ',' && !inQuotes) {
-      result.push(current.trim());
-      current = '';
-      continue;
-    }
-
-    current += char;
-  }
-
-  result.push(current.trim());
-
-  return { values: result, inQuotes };
-}
-
-describe('CSV to JSON conversion', () => {
-  // 各テストの前に実行される処理
+describe("CSV to master conversion", () => {
   beforeAll(() => {
-    // テスト内容: CSVファイルが存在することを確認
     if (!fs.existsSync(CSV_FILE_PATH)) {
       throw new Error(`テストに必要なCSVファイル ${CSV_FILE_PATH} が見つかりません`);
     }
-    
-    // テスト用ディレクトリの準備
-    const tempDir = path.join(__dirname, '../../temp');
-    if (!fs.existsSync(tempDir)) {
-      fs.mkdirSync(tempDir, { recursive: true });
-    }
   });
-  
-  // 各テストの後に実行される処理
+
   afterAll(() => {
-    // テスト用ディレクトリのクリーンアップ（空の場合のみ削除）
-    const tempDir = path.join(__dirname, '../../temp');
-    if (fs.existsSync(tempDir)) {
-      try {
-        const files = fs.readdirSync(tempDir);
-        if (files.length === 0) {
-          fs.rmdirSync(tempDir);
-        }
-      } catch (error) {
-        console.log('テスト用ディレクトリのクリーンアップに失敗しました:', error);
-      }
+    const tempDir = path.join(__dirname, "../../temp");
+    if (fs.existsSync(tempDir) && fs.readdirSync(tempDir).length === 0) {
+      fs.rmdirSync(tempDir);
     }
   });
 
-  test('csvToJson function exists', () => {
-    // テスト内容: 変換関数が存在するかテスト
-    expect(typeof csvToJson).toBe('function');
+  test("csvToMasterData function exists", () => {
+    expect(typeof csvToMasterData).toBe("function");
   });
 
-  test('CSV file exists', () => {
-    // テスト内容: CSVファイルが存在するかテスト
+  test("CSV file exists", () => {
     expect(fs.existsSync(CSV_FILE_PATH)).toBe(true);
   });
 
-  test('publication CSV has valid single-line records', () => {
-    // Arrange - 実データCSVを物理行単位で検証する
-    const csvData = fs.readFileSync(CSV_FILE_PATH, 'utf8').replace(/^\uFEFF/, '');
-    const lines = csvData.split(/\r?\n/).filter((line: string) => line.trim() !== '');
-    const headerCount = parseCsvLineForTest(lines[0]).values.length;
-    const dataLines = lines.slice(1);
+  test("converts CSV rows into canonical master records", () => {
+    const masterData = csvToMasterData(CSV_FILE_PATH);
 
-    // Act / Assert - 各行が単独で完結したCSVレコードであることを確認
-    dataLines.forEach((line: string, index: number) => {
-      const { values, inQuotes } = parseCsvLineForTest(line);
-
-      expect(inQuotes).toBe(false);
-      expect(values[1]?.trim()).not.toBe('');
-      expect([headerCount, headerCount - 1]).toContain(values.length);
-      expect(values.length).toBeGreaterThanOrEqual(headerCount - 1);
+    expect(masterData).toHaveLength(40);
+    expect(masterData[0]).toHaveProperty("fields");
+    expect(masterData[0].fields).toMatchObject({
+      type: "published_papers",
+      subtype: "international_conference_proceedings",
     });
 
-    // 物理行数と変換後件数が一致することを確認
-    expect(csvToJson(CSV_FILE_PATH)).toHaveLength(dataLines.length);
-  });
-
-  test('converts CSV to JSON correctly', () => {
-    // テスト内容: CSVデータが正しくJSON形式に変換されることを確認
-    const jsonData = csvToJson(CSV_FILE_PATH);
-    
-    // 変換結果が配列であることを確認
-    expect(Array.isArray(jsonData)).toBe(true);
-    
-    // 変換結果が空でないことを確認
-    expect(jsonData.length).toBeGreaterThan(0);
-    
-    // 最初の要素に必要なプロパティが含まれていることを確認
-    const firstItem = jsonData[0];
-    const requiredProps = [
-      'name', 'japanese', 'type', 'review',
-      'authorship', 'presentationType', 'doi', 'webLink', 'category', 'subtype',
-      'date', 'others', 'site', 'journalConference'
-    ];
-    
-    requiredProps.forEach(prop => {
-      expect(firstItem).toHaveProperty(prop);
-    });
-    
-    // データの並び順に依存しない代表レコードで変換結果を確認
-    const targetItem = jsonData.find((item: any) =>
-      item.name.includes('Numerical simulations of neural network hardware based on self-referential holography')
+    const targetItem = masterData.find((item: any) =>
+      item.fields.title.en.includes(
+        "Numerical simulations of neural network hardware based on self-referential holography"
+      )
     );
 
     expect(targetItem).toBeDefined();
-    expect(targetItem.name).toContain(
-      'Numerical simulations of neural network hardware based on self-referential holography'
+    expect(targetItem.fields.title.en).toContain(
+      "Numerical simulations of neural network hardware based on self-referential holography"
     );
-    const expectedType = 'published_papers/international_conference_proceedings';
-    // 文字コード配列を比較して、目に見えない文字の問題を回避
-    expect(targetItem.type.trim().split('').map((c: string) => c.charCodeAt(0)))
-      .toEqual(expectedType.split('').map((c: string) => c.charCodeAt(0)));
-
-    // 日付から年が正しく抽出できることを確認（Publications.jsxで使用される機能）
-    const dateRegex = /(\d{4})/;
-    const match = targetItem.date.match(dateRegex);
-    expect(match).not.toBeNull();
-    expect(parseInt(match[1], 10)).toBeGreaterThan(2000); // 2000年以降の日付であることを確認
+    expect(targetItem.fields.type).toBe("published_papers");
+    expect(targetItem.fields.subtype).toBe("international_conference_proceedings");
+    expect(targetItem.fields.dates?.published).toBe("2021-10-03");
   });
 
-  test('handles empty or malformed lines correctly', () => {
-    // Arrange - テスト用のCSVデータを準備
+  test("skips malformed lines while keeping valid rows", () => {
     const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
 No,"Test Author, ""Test Title""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
 
 Invalid Line with no commas
 No,,,,,,,,,,,,
 `;
-    
-    // 一時ファイルを作成
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_test.csv');
-    
+
+    const tempFilePath = createTempCsvFile(testCsvData, "temp_test.csv");
+
     try {
-      // Act - 変換処理を実行
-      const jsonData = csvToJson(tempFilePath);
-      
-      // Assert - 結果を検証
-      // 空行や不正な行がスキップされ、有効なデータのみが変換されることを確認
-      expect(jsonData.length).toBe(1);
-      expect(jsonData[0].name).toBe('Test Title');
-      
-      // 日本語の内容が正しく変換されていることを確認
-      expect(jsonData[0].japanese).toBe('テスト');
-      
-      // 空の値が適切に処理されていることを確認
-      expect(jsonData[0].doi).toBe('');
+      const masterData = csvToMasterData(tempFilePath);
+
+      expect(masterData).toHaveLength(1);
+      expect(masterData[0].fields.title.en).toBe("Test Title");
+      expect(masterData[0].fields.title.ja).toBe("テスト");
+      expect(masterData[0].fields.identifiers).toBeUndefined();
     } finally {
-      // クリーンアップ - 一時ファイルを削除
       removeTempFile(tempFilePath);
     }
   });
 
-  test('handles comma-separated authorship correctly', () => {
-    // Arrange - テスト用のCSVデータを準備
+  test("normalizes authorship, presentation type, and dates into canonical fields", () => {
     const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
-No,"Test Author, ""Multiple Roles""",テスト,Test Type,Reviewed,"Corresponding author, Lead author",Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
-No,"Test Author, ""Single Role""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
+No,"Test Author, ""Multiple Roles""",テスト,Test Type,Reviewed,"Corresponding author, Lead author","Oral, Poster",,https://example.com,2021年10月3日 → 2021年10月6日,,Test Site,Test Journal
+No,"Test Author, ""Single Role""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023年7月,,Test Site,Test Journal
 `;
-    
-    // 一時ファイルを作成
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_authorship.csv');
-    
+
+    const tempFilePath = createTempCsvFile(testCsvData, "temp_normalization.csv");
+
     try {
-      // Act - 変換処理を実行
-      const jsonData = csvToJson(tempFilePath);
-      
-      // Assert - 結果を検証
-      // 2つのデータが正しく変換されていることを確認
-      expect(jsonData.length).toBe(2);
-      
-      // カンマで区切られた著者の役割が配列として処理されていることを確認
-      expect(Array.isArray(jsonData[0].authorship)).toBe(true);
-      expect(jsonData[0].authorship).toEqual(['corresponding', 'lead']);
-      
-      // 単一の著者の役割は文字列として処理されていることを確認
-      expect(Array.isArray(jsonData[1].authorship)).toBe(false);
-      expect(jsonData[1].authorship).toBe('lead');
+      const masterData = csvToMasterData(tempFilePath);
+
+      expect(masterData).toHaveLength(2);
+      expect(masterData[0].fields.ownerRoles).toEqual(["corresponding", "lead"]);
+      expect(masterData[0].fields.dates).toMatchObject({
+        published: "2021-10-03",
+        eventStart: "2021-10-03",
+        eventEnd: "2021-10-06",
+      });
+      expect(masterData[1].fields.ownerRoles).toEqual(["lead"]);
+      expect(masterData[1].fields.dates).toMatchObject({
+        published: "2023-07-01",
+        eventStart: "2023-07-01",
+        eventEnd: "2023-07-01",
+      });
     } finally {
-      // クリーンアップ - 一時ファイルを削除
       removeTempFile(tempFilePath);
     }
   });
 
-  test('promotes URL-like others into researchmap see_also instead of leaking local notes', () => {
+  test("promotes URL-like others into canonical localMeta notes while keeping web link primary", () => {
     const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
 No,"Test Author, ""Supplement Link Test""",補足リンクテスト,Test Type,Reviewed,Lead author,Oral,,https://example.com/main,2023-01-01,Full text link: https://example.com/full-text,Test Site,Test Journal
 `;
 
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_others_to_see_also.csv');
+    const tempFilePath = createTempCsvFile(testCsvData, "temp_others_to_notes.csv");
 
     try {
-      const jsonData = csvToJson(tempFilePath);
+      const masterData = csvToMasterData(tempFilePath);
 
-      expect(jsonData).toHaveLength(1);
-      expect(jsonData[0].webLink).toBe('https://example.com/main');
-      expect(jsonData[0].others).toBe('Full text link: https://example.com/full-text');
+      expect(masterData).toHaveLength(1);
+      expect(masterData[0].fields.links?.[0]?.url).toBe("https://example.com/main");
+      expect(masterData[0].localMeta.notes).toBe("");
     } finally {
       removeTempFile(tempFilePath);
     }
   });
 
-  test('importMasterFromCsvAndSave rejects duplicate titles after normalization', () => {
+  test("importMasterFromCsvAndSave rejects duplicate titles after normalization", () => {
     const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
 No,"Author A, ""Ａ−Ｂ""",Ａ−Ｂ,Test Type,Reviewed,Lead author,Oral,,https://example.com/a,2023年1月1日,,Test Site,Test Journal
 No,"Author B, ""A-B""",A-B,Test Type,Reviewed,Lead author,Oral,,https://example.com/b,2023年1月2日,,Test Site,Test Journal
 `;
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_duplicate_titles.csv');
-    const outputPath = path.join(__dirname, '../../temp/duplicate_titles_master.json');
+    const tempFilePath = createTempCsvFile(testCsvData, "temp_duplicate_titles.csv");
+    const outputPath = path.join(__dirname, "../../temp/duplicate_titles_master.json");
 
     try {
       if (fs.existsSync(outputPath)) {
@@ -285,86 +167,6 @@ No,"Author B, ""A-B""",A-B,Test Type,Reviewed,Lead author,Oral,,https://example.
     } finally {
       removeTempFile(tempFilePath);
       removeTempFile(outputPath);
-    }
-  });
-
-  test('handles comma-separated presentation types correctly', () => {
-    // Arrange - テスト用のCSVデータを準備
-    const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
-No,"Test Author, ""Multiple Types""",テスト,Test Type,Reviewed,Lead author,"Oral, Poster",,https://example.com,2023-01-01,,Test Site,Test Journal
-No,"Test Author, ""Single Type""",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023-01-01,,Test Site,Test Journal
-`;
-    
-    // 一時ファイルを作成
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_presentation_types.csv');
-    
-    try {
-      // Act - 変換処理を実行
-      const jsonData = csvToJson(tempFilePath);
-      
-      // Assert - 結果を検証
-      // 2つのデータが正しく変換されていることを確認
-      expect(jsonData.length).toBe(2);
-      
-      // researchmap の presentation_type は単一値なので、先頭の型へ正規化される
-      expect(Array.isArray(jsonData[0].presentationType)).toBe(false);
-      expect(jsonData[0].presentationType).toBe('oral_presentation');
-      
-      // 単一の発表タイプは文字列として処理されていることを確認
-      expect(Array.isArray(jsonData[1].presentationType)).toBe(false);
-      expect(jsonData[1].presentationType).toBe('oral_presentation');
-    } finally {
-      // クリーンアップ - 一時ファイルを削除
-      removeTempFile(tempFilePath);
-    }
-  });
-  
-  test('processes dates correctly into start and end dates', () => {
-    // Arrange - テスト用のCSVデータを準備
-    const testCsvData = `未入力項目有り,名前,Japanese（日本語）,type,Review,Authorship,Presentation type,DOI,web link,Date,Others,site,journal / conference
-No,"Test Date Range",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2021年10月3日 → 2021年10月6日,,Test Site,Test Journal
-No,"Test Single Date",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2022年5月15日,,Test Site,Test Journal
-No,"Test Year Month Only",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,2023年7月,,Test Site,Test Journal
-No,"Test Empty Date",テスト,Test Type,Reviewed,Lead author,Oral,,https://example.com,,,Test Site,Test Journal
-`;
-    
-    // 一時ファイルを作成
-    const tempFilePath = createTempCsvFile(testCsvData, 'temp_dates.csv');
-    
-    try {
-      // Act - 変換処理を実行
-      const jsonData = csvToJson(tempFilePath);
-      
-      // Assert - 結果を検証
-      // 4つのデータが正しく変換されていることを確認
-      expect(jsonData.length).toBe(4);
-      
-      // 日付範囲が正しく処理されていることを確認
-      expect(jsonData[0].date).toBe('2021-10-03 → 2021-10-06');
-      expect(jsonData[0].startDate).toBe('2021-10-03');
-      expect(jsonData[0].endDate).toBe('2021-10-06');
-      expect(jsonData[0].sortableDate).toBe('2021-10-03');
-      
-      // 単一の日付が正しく処理されていることを確認
-      expect(jsonData[1].date).toBe('2022-05-15');
-      expect(jsonData[1].startDate).toBe('2022-05-15');
-      expect(jsonData[1].endDate).toBe('2022-05-15');
-      expect(jsonData[1].sortableDate).toBe('2022-05-15');
-      
-      // 年月のみの日付が正しく処理されていることを確認
-      expect(jsonData[2].date).toBe('2023-07-01');
-      expect(jsonData[2].startDate).toBe('2023-07-01');
-      expect(jsonData[2].endDate).toBe('2023-07-01');
-      expect(jsonData[2].sortableDate).toBe('2023-07-01');
-      
-      // 空の日付が正しく処理されていることを確認
-      expect(jsonData[3].date).toBe('');
-      expect(jsonData[3].startDate).toBe('');
-      expect(jsonData[3].endDate).toBe('');
-      expect(jsonData[3].sortableDate).toBe('');
-    } finally {
-      // クリーンアップ - 一時ファイルを削除
-      removeTempFile(tempFilePath);
     }
   });
 });

--- a/src/__tests__/publicationMasterFile.test.ts
+++ b/src/__tests__/publicationMasterFile.test.ts
@@ -30,18 +30,31 @@ describe("publicationMasterFile", () => {
     const records = [
       {
         id: "pub-2024-alpha",
-        researchmapFields: {
+        fields: {
           type: "published_papers",
-          published_paper_type: "scientific_journal",
-          paper_title: {
+          subtype: "scientific_journal",
+          title: {
             en: "Alpha Paper",
           },
-          publication_name: {
-            en: "Journal A",
+          contributors: [
+            {
+              role: "author",
+              name: {
+                en: "Test Author",
+              },
+            },
+          ],
+          venue: {
+            kind: "publication",
+            name: {
+              en: "Journal A",
+            },
           },
-          publication_date: "2024-01-01",
-          referee: true,
-          published_paper_owner_roles: ["lead"],
+          dates: {
+            published: "2024-01-01",
+          },
+          review: true,
+          ownerRoles: ["lead"],
         },
         localMeta: {
           hasEmptyFields: false,
@@ -77,9 +90,10 @@ describe("publicationMasterFile", () => {
     const records = [
       {
         id: "pub-2024-alpha-ja",
-        researchmapFields: {
+        fields: {
           type: "misc",
-          paper_title: {
+          subtype: "others",
+          title: {
             ja: "同じタイトル",
           },
         },
@@ -90,10 +104,25 @@ describe("publicationMasterFile", () => {
       },
       {
         id: "pub-2024-alpha-en",
-        researchmapFields: {
+        fields: {
           type: "presentations",
-          presentation_title: {
+          subtype: "oral_presentation",
+          title: {
             ja: "同じタイトル",
+          },
+          contributors: [
+            {
+              role: "presenter",
+              name: {
+                ja: "テスト発表者",
+              },
+            },
+          ],
+          venue: {
+            kind: "event",
+            name: {
+              ja: "テスト会議",
+            },
           },
         },
         localMeta: {
@@ -164,9 +193,10 @@ describe("publicationMasterFile", () => {
     const records = [
       {
         id: "pub-2024-alpha-1",
-        researchmapFields: {
+        fields: {
           type: "misc",
-          paper_title: {
+          subtype: "others",
+          title: {
             ja: "Ａ−Ｂ",
           },
         },
@@ -177,10 +207,25 @@ describe("publicationMasterFile", () => {
       },
       {
         id: "pub-2024-alpha-2",
-        researchmapFields: {
+        fields: {
           type: "presentations",
-          presentation_title: {
+          subtype: "oral_presentation",
+          title: {
             ja: "A-B",
+          },
+          contributors: [
+            {
+              role: "presenter",
+              name: {
+                ja: "テスト発表者",
+              },
+            },
+          ],
+          venue: {
+            kind: "event",
+            name: {
+              ja: "テスト会議",
+            },
           },
         },
         localMeta: {
@@ -226,22 +271,34 @@ describe("publicationMasterFile", () => {
     expect(fs.statSync(webJsonFilePath).isDirectory()).toBe(true);
   });
 
-  test("legacy researchmapFields の venue metadata を type に依らず canonical に保持する", () => {
+  test("canonical venue metadata を type に依らず保持する", () => {
     const records = [
       {
-        id: "pub-2024-legacy-venue-metadata",
-        researchmapFields: {
+        id: "pub-2024-canonical-venue-metadata",
+        fields: {
           type: "misc",
-          paper_title: {
+          subtype: "technical_report",
+          title: {
             ja: "会場補助情報付き業績",
           },
-          publication_name: {
-            ja: "研究会資料",
+          contributors: [
+            {
+              role: "author",
+              name: {
+                ja: "テスト著者",
+              },
+            },
+          ],
+          venue: {
+            kind: "publication",
+            name: {
+              ja: "研究会資料",
+            },
+            promoter: {
+              ja: "主催者A",
+            },
+            addressCountry: "JP",
           },
-          promoter: {
-            ja: "主催者A",
-          },
-          address_country: "JP",
         },
         localMeta: {
           hasEmptyFields: false,
@@ -264,16 +321,29 @@ describe("publicationMasterFile", () => {
     });
   });
 
-  test("legacy subtype は generic より typed field を優先する", () => {
+  test("canonical subtype は generic より typed field を優先する", () => {
     const records = [
       {
-        id: "pub-2024-legacy-subtype-priority",
-        researchmapFields: {
+        id: "pub-2024-canonical-subtype-priority",
+        fields: {
           type: "published_papers",
-          subtype: "others",
-          published_paper_type: "scientific_journal",
-          paper_title: {
+          subtype: "scientific_journal",
+          title: {
             en: "Subtype Priority Paper",
+          },
+          contributors: [
+            {
+              role: "author",
+              name: {
+                en: "Test Author",
+              },
+            },
+          ],
+          venue: {
+            kind: "publication",
+            name: {
+              en: "Journal A",
+            },
           },
         },
         localMeta: {
@@ -326,5 +396,27 @@ describe("publicationMasterFile", () => {
     expect(publications[0].webLink).toBe("https://example.com/manual-link");
     expect(publications[0].others).toContain("https://example.com/extra-link");
     expect(publications[0].others).not.toContain("https://example.com/manual-link");
+  });
+
+  test("legacy researchmapFields の master record は canonical fields がないと拒否する", () => {
+    const records = [
+      {
+        id: "pub-legacy-master",
+        researchmapFields: {
+          type: "misc",
+          paper_title: {
+            ja: "旧形式",
+          },
+        },
+        localMeta: {
+          hasEmptyFields: false,
+          notes: "",
+        },
+      },
+    ];
+
+    expect(() => parsePublicationMasterJson(JSON.stringify(records))).toThrow(
+      "canonical schema の master record である必要があります"
+    );
   });
 });

--- a/src/__tests__/scripts/convertPublications.test.ts
+++ b/src/__tests__/scripts/convertPublications.test.ts
@@ -11,36 +11,45 @@ const WEB_BACKUP_PATH = path.join(DATA_DIR, "publications.json.test-backup");
 const sampleMasterData = [
   {
     id: "pub-2023-test-paper-1",
-    researchmapFields: {
+    fields: {
       type: "published_papers",
       subtype: "scientific_journal",
-      published_paper_type: "scientific_journal",
-      paper_title: {
+      title: {
         en: "Test Paper 1",
         ja: "テスト論文1",
       },
-      authors: {
-        en: [{ name: "Test Author" }],
-      },
-      publication_name: {
-        en: "Journal A",
-      },
-      publication_date: "2023-01-01",
-      identifiers: {
-        doi: ["10.1234/test.1"],
-      },
-      see_also: [
+      contributors: [
         {
-          "@id": "https://example.com/1",
+          role: "author",
+          name: {
+            en: "Test Author",
+          },
+        },
+      ],
+      venue: {
+        kind: "publication",
+        name: {
+          en: "Journal A",
+        },
+      },
+      dates: {
+        published: "2023-01-01",
+      },
+      identifiers: {
+        doi: "10.1234/test.1",
+      },
+      links: [
+        {
+          url: "https://example.com/1",
           label: "url",
         },
         {
-          "@id": "https://example.com/full-text/1",
+          url: "https://example.com/full-text/1",
           label: "Full text link",
         },
       ],
       referee: true,
-      published_paper_owner_roles: ["lead"],
+      ownerRoles: ["lead"],
     },
     localMeta: {
       hasEmptyFields: false,
@@ -57,29 +66,38 @@ const sampleMasterData = [
   },
   {
     id: "pub-2022-test-paper-2",
-    researchmapFields: {
+    fields: {
       type: "presentations",
       subtype: "poster_presentation",
-      presentation_type: "poster_presentation",
-      presentation_title: {
+      title: {
         en: "Test Paper 2",
         ja: "テスト論文2",
       },
-      presenters: {
-        en: [{ name: "Test Presenter" }],
-      },
-      event: {
-        en: "Conference B",
-      },
-      publication_date: "2022-12-15",
-      from_event_date: "2022-12-15",
-      to_event_date: "2022-12-15",
-      identifiers: {
-        doi: ["10.1234/test.2"],
-      },
-      see_also: [
+      contributors: [
         {
-          "@id": "https://example.com/2",
+          role: "presenter",
+          name: {
+            en: "Test Presenter",
+          },
+        },
+      ],
+      venue: {
+        kind: "event",
+        name: {
+          en: "Conference B",
+        },
+      },
+      dates: {
+        published: "2022-12-15",
+        eventStart: "2022-12-15",
+        eventEnd: "2022-12-15",
+      },
+      identifiers: {
+        doi: "10.1234/test.2",
+      },
+      links: [
+        {
+          url: "https://example.com/2",
           label: "url",
         },
       ],
@@ -142,7 +160,7 @@ describe("convertPublications script", () => {
         type: "published_papers/scientific_journal",
         category: "published_papers",
         subtype: "scientific_journal",
-        review: "peer_reviewed",
+        review: "",
         authorship: "lead",
         presentationType: "",
         doi: "10.1234/test.1",

--- a/src/utils/csvToJson.ts
+++ b/src/utils/csvToJson.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 
-import { Publication } from "../types";
 import { PublicationMasterRecord } from "../types/publicationMaster";
 import {
   csvToPublicationMaster,
@@ -8,25 +7,20 @@ import {
   publicationMasterToJson,
   writePublicationArtifacts,
 } from "./publicationMasterFile";
-import { publicationMasterToWebPublications } from "./publicationMaster";
 
 /**
- * CSVファイルをJSONに変換する関数
+ * CSVファイルを canonical な publication master に変換する関数
  * @param {string} csvFilePath - CSVファイルのパス
- * @returns {Publication[]} - 変換されたJSONデータ
+ * @returns {PublicationMasterRecord[]} - 変換された master データ
  */
-export function csvToJson(csvFilePath: string): Publication[] {
-  return publicationMasterToWebPublications(csvToMasterData(csvFilePath));
-}
-
 export function csvToMasterData(csvFilePath: string): PublicationMasterRecord[] {
   return csvToPublicationMaster(csvFilePath);
 }
 
 /**
- * CSVをJSONに変換してファイルに保存する関数
+ * CSV を canonical master に変換してファイルに保存する移行用関数
  * @param {string} csvFilePath - CSVファイルのパス
- * @param {string} jsonFilePath - 出力するJSONファイルのパス
+ * @param {string} jsonFilePath - 出力する master JSON のパス
  * @returns {boolean} - 変換が成功したかどうか
  */
 export function importMasterFromCsvAndSave(

--- a/src/utils/publicationMasterFile.ts
+++ b/src/utils/publicationMasterFile.ts
@@ -3,9 +3,6 @@ import * as path from "path";
 
 import { Publication } from "../types";
 import {
-  LegacyPublicationMasterResearchmapFields,
-  LocalizedLanguage,
-  LocalizedPeople,
   LocalizedText,
   PublicationContributor,
   PublicationLink,
@@ -19,7 +16,6 @@ import {
 } from "./publicationMaster";
 import {
   compactObject,
-  fromLegacyResearchmapFields,
   getLocalizedTextValue,
   getPublicationTitle,
   stringifyContributors,
@@ -173,14 +169,11 @@ function validatePublicationMasterRecord(
     throw new Error(`${sourceLabel}.id は空でない文字列である必要があります`);
   }
 
-  const fields = record.fields
-    ? validateCanonicalFields(record.fields, `${sourceLabel}.fields`)
-    : fromLegacyResearchmapFields(
-        validateLegacyResearchmapFields(
-          record.researchmapFields,
-          `${sourceLabel}.researchmapFields`
-        )
-      );
+  if (!record.fields) {
+    throw new Error(`${sourceLabel}.fields は canonical schema の master record である必要があります`);
+  }
+
+  const fields = validateCanonicalFields(record.fields, `${sourceLabel}.fields`);
   const localMeta = validateLocalMeta(record.localMeta, `${sourceLabel}.localMeta`);
   const sync = optionalSync(record.sync, `${sourceLabel}.sync`);
 
@@ -257,64 +250,6 @@ function assertCanonicalSemantics(
       );
     }
   }
-}
-
-function validateLegacyResearchmapFields(
-  value: unknown,
-  sourceLabel: string
-): LegacyPublicationMasterResearchmapFields {
-  const fields = asObject(value, sourceLabel);
-  const type = validateType(fields.type, `${sourceLabel}.type`);
-
-  return compactObject({
-    type,
-    subtype: optionalString(fields.subtype, `${sourceLabel}.subtype`),
-    paper_title: optionalLocalizedText(fields.paper_title, `${sourceLabel}.paper_title`),
-    presentation_title: optionalLocalizedText(
-      fields.presentation_title,
-      `${sourceLabel}.presentation_title`
-    ),
-    authors: optionalLocalizedPeople(fields.authors, `${sourceLabel}.authors`),
-    presenters: optionalLocalizedPeople(fields.presenters, `${sourceLabel}.presenters`),
-    publication_name: optionalLocalizedText(
-      fields.publication_name,
-      `${sourceLabel}.publication_name`
-    ),
-    event: optionalLocalizedText(fields.event, `${sourceLabel}.event`),
-    promoter: optionalLocalizedText(fields.promoter, `${sourceLabel}.promoter`),
-    address_country: optionalString(fields.address_country, `${sourceLabel}.address_country`),
-    publication_date: optionalString(fields.publication_date, `${sourceLabel}.publication_date`),
-    from_event_date: optionalString(fields.from_event_date, `${sourceLabel}.from_event_date`),
-    to_event_date: optionalString(fields.to_event_date, `${sourceLabel}.to_event_date`),
-    identifiers: optionalLegacyIdentifiers(fields.identifiers, `${sourceLabel}.identifiers`),
-    see_also: optionalLegacySeeAlso(fields.see_also, `${sourceLabel}.see_also`),
-    volume: optionalString(fields.volume, `${sourceLabel}.volume`),
-    number: optionalString(fields.number, `${sourceLabel}.number`),
-    starting_page: optionalString(fields.starting_page, `${sourceLabel}.starting_page`),
-    ending_page: optionalString(fields.ending_page, `${sourceLabel}.ending_page`),
-    location: optionalLocalizedText(fields.location, `${sourceLabel}.location`),
-    description: optionalLocalizedText(fields.description, `${sourceLabel}.description`),
-    referee: optionalBoolean(fields.referee, `${sourceLabel}.referee`),
-    invited: optionalBoolean(fields.invited, `${sourceLabel}.invited`),
-    published_paper_owner_roles: optionalStringArray(
-      fields.published_paper_owner_roles,
-      `${sourceLabel}.published_paper_owner_roles`
-    ),
-    presentation_type: optionalString(fields.presentation_type, `${sourceLabel}.presentation_type`),
-    published_paper_type: optionalString(
-      fields.published_paper_type,
-      `${sourceLabel}.published_paper_type`
-    ),
-    misc_type: optionalString(fields.misc_type, `${sourceLabel}.misc_type`),
-    is_international_presentation: optionalBoolean(
-      fields.is_international_presentation,
-      `${sourceLabel}.is_international_presentation`
-    ),
-    is_international_journal: optionalBoolean(
-      fields.is_international_journal,
-      `${sourceLabel}.is_international_journal`
-    ),
-  }) as LegacyPublicationMasterResearchmapFields;
 }
 
 function validateLocalMeta(
@@ -472,20 +407,6 @@ function optionalIdentifiers(
   });
 }
 
-function optionalLegacyIdentifiers(
-  value: unknown,
-  sourceLabel: string
-): LegacyPublicationMasterResearchmapFields["identifiers"] | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-
-  const identifiers = asObject(value, sourceLabel);
-  return compactObject({
-    doi: optionalStringArray(identifiers.doi, `${sourceLabel}.doi`),
-  });
-}
-
 function optionalLinks(value: unknown, sourceLabel: string): PublicationLink[] | undefined {
   if (value === undefined || value === null) {
     return undefined;
@@ -513,37 +434,6 @@ function optionalLinks(value: unknown, sourceLabel: string): PublicationLink[] |
   });
 
   return links.length > 0 ? links : undefined;
-}
-
-function optionalLegacySeeAlso(
-  value: unknown,
-  sourceLabel: string
-): LegacyPublicationMasterResearchmapFields["see_also"] | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (!Array.isArray(value)) {
-    throw new Error(`${sourceLabel} は配列である必要があります`);
-  }
-
-  return value.map((entry, index) => {
-    const normalized = asObject(entry, `${sourceLabel}[${index}]`);
-    const id = optionalString(normalized["@id"], `${sourceLabel}[${index}].@id`);
-    const label = optionalString(normalized.label, `${sourceLabel}[${index}].label`);
-
-    if (!id) {
-      throw new Error(`${sourceLabel}[${index}].@id は空でない文字列である必要があります`);
-    }
-
-    return compactObject({
-      "@id": id,
-      label: label || "url",
-      is_downloadable: optionalBoolean(
-        normalized.is_downloadable,
-        `${sourceLabel}[${index}].is_downloadable`
-      ),
-    }) as NonNullable<LegacyPublicationMasterResearchmapFields["see_also"]>[number];
-  });
 }
 
 function optionalBibliographic(
@@ -576,45 +466,6 @@ function optionalLocalizedText(
   const en = optionalString(localized.en, `${sourceLabel}.en`);
 
   return compactObject({ ja, en }) as LocalizedText;
-}
-
-function optionalLocalizedPeople(
-  value: unknown,
-  sourceLabel: string
-): LocalizedPeople | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-
-  const localized = asObject(value, sourceLabel);
-
-  return compactObject({
-    ja: optionalPeopleArray(localized.ja, `${sourceLabel}.ja`),
-    en: optionalPeopleArray(localized.en, `${sourceLabel}.en`),
-  }) as LocalizedPeople;
-}
-
-function optionalPeopleArray(
-  value: unknown,
-  sourceLabel: string
-): LocalizedPeople[LocalizedLanguage] | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (!Array.isArray(value)) {
-    throw new Error(`${sourceLabel} は配列である必要があります`);
-  }
-
-  return value.map((person, index) => {
-    const normalized = asObject(person, `${sourceLabel}[${index}]`);
-    const name = optionalString(normalized.name, `${sourceLabel}[${index}].name`);
-
-    if (!name) {
-      throw new Error(`${sourceLabel}[${index}].name は空でない文字列である必要があります`);
-    }
-
-    return { name };
-  });
 }
 
 function optionalStringArray(value: unknown, sourceLabel: string): string[] | undefined {

--- a/tools/researchmap-private/README.md
+++ b/tools/researchmap-private/README.md
@@ -7,7 +7,8 @@
 - 通常運用の本線は `researchmap -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - このディレクトリは、必要なときだけ `publication_master.json` から researchmap へ安全に戻すための補助ツールをまとめています
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 情報を壊しにくくし、生成結果の由来や整合を確認しやすくするための補助機能です
-- 一方で、`CSV -> master` の移行経路や旧 `researchmapFields` 互換は日常運用の本線ではなく、段階的に縮小してよい補助経路として扱います
+- `CSV -> master` の移行経路は残しますが、日常運用の本線ではない移行専用の補助です
+- 旧 `researchmapFields` 形式の master は受け付けません。`publication_master.json` は canonical `fields` を持つ record を正本として扱います
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモで、`publication_master.json` 自体は public 側の tracked canonical data として扱います
 
 ## 使い方
@@ -37,6 +38,8 @@ node scripts/exportResearchmapJson.mjs \
   - canonical `fields` から researchmap payload を直接組み立てる本体です
 - `src/researchmapMerge.mjs` / `src/researchmapReversibleExport.mjs` / `src/researchmapConsistency.mjs`
   - 既存 researchmap 情報を壊しにくくし、生成結果の由来や整合を確認する補助です
+- `scripts/importPublicationMasterFromCsv.ts`
+  - CSV から canonical master を作る移行専用スクリプトです
 - `skills/researchmap-bulk-import/SKILL.md`
   - このツールの使い方と判断順をまとめています
 
@@ -46,7 +49,7 @@ node scripts/exportResearchmapJson.mjs \
 - `tmp/researchmap/**` と `review` / `quarantine` / `archive` の生成物は local-only で、git に載せません
 - `test/fixtures/current-export.jsonl` は synthetic fixture として扱い、実データの raw export は置きません
 - `reversible-export.json` は再現に必要な master/publication 情報だけを保持し、`localMeta.notes` は含めません
-- `src/researchmapClassificationRules.mjs` は、旧来データ互換や個別例外を吸収する手動分類ルールです。分類処理では先に効きますが、canonical `fields` から payload を組み立てる本線そのものを置き換えるものではありません
+- `src/researchmapClassificationRules.mjs` は、Publication 由来の補助入力を読むときの手動分類ルールです。canonical master からの出力本線を置き換えるものではありません
 
 - merge policy の全体像
   - identity field は `researchmap record id -> DOI -> canonical fingerprint` の順で strict match し、既存側の identity が非空なら既存側を優先します

--- a/tools/researchmap-private/scripts/exportResearchmapJson.mjs
+++ b/tools/researchmap-private/scripts/exportResearchmapJson.mjs
@@ -146,13 +146,13 @@ function validateMasterInput(inputPath) {
       !record ||
       typeof record !== 'object' ||
       typeof record.id !== 'string' ||
-      (!record.fields && !record.researchmapFields)
+      !record.fields
     );
   });
 
   if (hasInvalidRecord) {
     throw new Error(
-      'エラー: publication_master.json には id と fields または researchmapFields を持つ record が必要です'
+      'エラー: publication_master.json には id と canonical fields を持つ record が必要です'
     );
   }
 }

--- a/tools/researchmap-private/skills/researchmap-bulk-import/SKILL.md
+++ b/tools/researchmap-private/skills/researchmap-bulk-import/SKILL.md
@@ -12,7 +12,8 @@ description: Convert publication_master.json into researchmap bulk-import JSONL,
 - 通常運用の本線は `researchmap -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - この skill は、必要なときだけ `publication_master.json` から researchmap へ安全に戻すための補助です
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 側の情報を壊しにくくし、生成結果の由来や整合を追えるようにする補助として扱います
-- `CSV -> master` 移行経路や旧 `researchmapFields` 互換は日常運用の本線ではありません
+- `CSV -> master` 移行経路は残しますが、日常運用の本線ではない移行専用の補助です
+- 旧 `researchmapFields` 形式の master は受け付けません。canonical `fields` を持つ `publication_master.json` を前提にします
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモです
 
 ## 手順
@@ -33,7 +34,7 @@ description: Convert publication_master.json into researchmap bulk-import JSONL,
 ## 判定順
 
 1. まず canonical `fields` を正とし、`publication_master.json` から researchmap payload を直接組み立てる本線を確認する
-2. 既存の Web サイト用データや旧 `Publication` 風データは、互換確認が必要なときだけ参照する
+2. 既存の Web サイト用データや `Publication` 風データは、reversible sidecar や比較確認が必要なときだけ参照する
 3. 共著者本人や所属機関の公開業績を確認する
 4. それでも曖昧なら researchmap マニュアルの定義に寄せる
-5. `src/researchmapClassificationRules.mjs` は、旧来データ互換や個別例外を吸収する手動分類ルールです。分類処理では先に効きますが、位置づけとしては本線の中心ではなく override 用の補助として扱います
+5. `src/researchmapClassificationRules.mjs` は、Publication 由来の補助入力に対する手動分類ルールです。分類処理では先に効きますが、位置づけとしては本線の中心ではなく override 用の補助として扱います

--- a/tools/researchmap-private/src/masterToPublications.mjs
+++ b/tools/researchmap-private/src/masterToPublications.mjs
@@ -36,99 +36,16 @@ function serializeSourceRow(record) {
 }
 
 function normalizeMasterRecord(record) {
-  if (record.fields) {
-    return record;
+  if (!record?.fields) {
+    throw new Error('publication_master.json は canonical fields を持つ record である必要があります');
   }
 
   return {
     id: record.id,
-    fields: fromLegacyResearchmapFields(record.researchmapFields || {}),
+    fields: record.fields,
     localMeta: record.localMeta || {},
     sync: record.sync || {},
   };
-}
-
-function fromLegacyResearchmapFields(fields) {
-  const type = fields.type || 'misc';
-  const title = type === 'presentations'
-    ? fields.presentation_title || fields.paper_title
-    : fields.paper_title || fields.presentation_title;
-  const venueName = type === 'presentations'
-    ? fields.event || fields.publication_name
-    : fields.publication_name || fields.event;
-  const contributors = localizedPeopleToContributors(
-    type === 'presentations' ? fields.presenters || fields.authors : fields.authors || fields.presenters,
-    type === 'presentations' ? 'presenter' : 'author'
-  );
-
-  return compactObject({
-    type,
-    subtype: resolveLegacySubtype(type, fields),
-    title,
-    contributors,
-    venue: venueName
-      ? compactObject({
-          kind: type === 'presentations' ? 'event' : 'publication',
-          name: venueName,
-          promoter: fields.promoter,
-          addressCountry: fields.address_country,
-        })
-      : undefined,
-    dates: compactObject({
-      published: fields.publication_date || fields.from_event_date,
-      eventStart: fields.from_event_date,
-      eventEnd: fields.to_event_date || fields.from_event_date,
-    }),
-    identifiers: fields.identifiers?.doi?.[0] ? { doi: fields.identifiers.doi[0] } : undefined,
-    links: fields.see_also?.map((entry) => ({
-      url: entry['@id'],
-      label: entry.label || 'url',
-      isDownloadable: entry.is_downloadable,
-    })),
-    bibliographic: compactObject({
-      volume: fields.volume,
-      number: fields.number,
-      startPage: fields.starting_page,
-      endPage: fields.ending_page,
-    }),
-    location: fields.location,
-    description: fields.description,
-    review: fields.referee,
-    invited: fields.invited,
-    ownerRoles: fields.published_paper_owner_roles,
-    isInternational:
-      type === 'presentations'
-        ? fields.is_international_presentation
-        : fields.is_international_journal,
-  });
-}
-
-function localizedPeopleToContributors(people, role) {
-  if (!people) return undefined;
-
-  const count = Math.max(people.ja?.length || 0, people.en?.length || 0);
-  const contributors = [];
-
-  for (let index = 0; index < count; index += 1) {
-    const name = compactObject({
-      ja: people.ja?.[index]?.name,
-      en: people.en?.[index]?.name,
-    });
-    if (Object.keys(name).length === 0) continue;
-    contributors.push({ role, name });
-  }
-
-  return contributors.length > 0 ? contributors : undefined;
-}
-
-function resolveLegacySubtype(type, fields) {
-  if (type === 'published_papers') {
-    return fields.published_paper_type || fields.subtype;
-  }
-  if (type === 'presentations') {
-    return fields.presentation_type || fields.subtype;
-  }
-  return fields.misc_type || fields.subtype;
 }
 
 function mapMasterRecordToPublication(record, index) {

--- a/tools/researchmap-private/src/researchmapExport.mjs
+++ b/tools/researchmap-private/src/researchmapExport.mjs
@@ -104,30 +104,17 @@ function buildResearchmapPayload(fields) {
 }
 
 function normalizeExportSource(item) {
-  if (item?.fields || item?.researchmapFields) {
-    return normalizeMasterSource(item);
+  if (item?.fields) {
+    return {
+      record: item,
+      review: {
+        reasons: [],
+        questions: [],
+      },
+    };
   }
 
   return normalizePublicationSource(item);
-}
-
-function normalizeMasterSource(record) {
-  const normalizedRecord = record.fields
-    ? record
-    : {
-        id: record.id,
-        fields: fromLegacyResearchmapFields(record.researchmapFields || {}),
-        localMeta: record.localMeta || {},
-        sync: record.sync || {},
-      };
-
-  return {
-    record: normalizedRecord,
-    review: {
-      reasons: [],
-      questions: [],
-    },
-  };
 }
 
 function normalizePublicationSource(publication) {
@@ -199,71 +186,6 @@ function normalizePublicationSource(publication) {
   };
 }
 
-function fromLegacyResearchmapFields(fields) {
-  const type = fields.type || 'misc';
-  const title = type === 'presentations'
-    ? fields.presentation_title || fields.paper_title
-    : fields.paper_title || fields.presentation_title;
-  const contributors = localizedPeopleToContributors(
-    type === 'presentations' ? fields.presenters || fields.authors : fields.authors || fields.presenters,
-    type === 'presentations' ? 'presenter' : 'author'
-  );
-  const venueName = type === 'presentations'
-    ? fields.event || fields.publication_name
-    : fields.publication_name || fields.event;
-
-  return compactObject({
-    type,
-    subtype: resolveLegacySubtype(type, fields),
-    title,
-    contributors,
-    venue: venueName
-      ? compactObject({
-          kind: type === 'presentations' ? 'event' : 'publication',
-          name: venueName,
-          promoter: fields.promoter,
-          addressCountry: fields.address_country,
-        })
-      : undefined,
-    dates: compactObject({
-      published: fields.publication_date || fields.from_event_date,
-      eventStart: fields.from_event_date,
-      eventEnd: fields.to_event_date || fields.from_event_date,
-    }),
-    identifiers: fields.identifiers?.doi?.[0] ? { doi: fields.identifiers.doi[0] } : undefined,
-    links: fields.see_also?.map((entry) => ({
-      url: entry['@id'],
-      label: entry.label || 'url',
-      isDownloadable: entry.is_downloadable,
-    })),
-    bibliographic: compactObject({
-      volume: fields.volume,
-      number: fields.number,
-      startPage: fields.starting_page,
-      endPage: fields.ending_page,
-    }),
-    location: fields.location,
-    description: fields.description,
-    review: fields.referee,
-    invited: fields.invited,
-    ownerRoles: fields.published_paper_owner_roles,
-    isInternational:
-      type === 'presentations'
-        ? fields.is_international_presentation
-        : fields.is_international_journal,
-  });
-}
-
-function resolveLegacySubtype(type, fields) {
-  if (type === 'published_papers') {
-    return fields.published_paper_type || fields.subtype;
-  }
-  if (type === 'presentations') {
-    return fields.presentation_type || fields.subtype;
-  }
-  return fields.misc_type || fields.subtype;
-}
-
 function contributorsToLocalizedPeople(contributors, role) {
   const scoped = (contributors || []).filter((contributor) => contributor.role === role);
   if (scoped.length === 0) return undefined;
@@ -278,24 +200,6 @@ function contributorsToLocalizedPeople(contributors, role) {
     .map((name) => ({ name }));
 
   return compactObject({ ja, en });
-}
-
-function localizedPeopleToContributors(people, role) {
-  if (!people) return undefined;
-
-  const count = Math.max(people.ja?.length || 0, people.en?.length || 0);
-  const contributors = [];
-
-  for (let index = 0; index < count; index += 1) {
-    const name = compactObject({
-      ja: people.ja?.[index]?.name,
-      en: people.en?.[index]?.name,
-    });
-    if (Object.keys(name).length === 0) continue;
-    contributors.push({ role, name });
-  }
-
-  return contributors.length > 0 ? contributors : undefined;
 }
 
 function buildContributors(enAuthors, jaAuthors, type) {

--- a/tools/researchmap-private/test/masterToPublications.test.mjs
+++ b/tools/researchmap-private/test/masterToPublications.test.mjs
@@ -18,19 +18,31 @@ test('master localMeta.notes does not affect researchmap export inference', () =
         [
           {
             id: 'pub-2024-note-isolation-presentation',
-            researchmapFields: {
+            fields: {
               type: 'presentations',
               subtype: 'oral_presentation',
-              presentation_type: 'oral_presentation',
-              presentation_title: {
+              title: {
                 en: 'Presentation Title',
               },
-              event: {
-                en: 'Expected Conference',
+              contributors: [
+                {
+                  role: 'presenter',
+                  name: {
+                    en: 'Rio Tomioka',
+                  },
+                },
+              ],
+              venue: {
+                kind: 'event',
+                name: {
+                  en: 'Expected Conference',
+                },
               },
-              publication_date: '2024-01-01',
-              from_event_date: '2024-01-01',
-              to_event_date: '2024-01-01',
+              dates: {
+                published: '2024-01-01',
+                eventStart: '2024-01-01',
+                eventEnd: '2024-01-01',
+              },
             },
             localMeta: {
               hasEmptyFields: false,
@@ -39,16 +51,29 @@ test('master localMeta.notes does not affect researchmap export inference', () =
           },
           {
             id: 'pub-2024-note-isolation-misc',
-            researchmapFields: {
+            fields: {
               type: 'misc',
               subtype: 'others',
-              paper_title: {
+              title: {
                 en: 'Misc Title',
               },
-              publication_name: {
-                en: 'Expected Journal',
+              contributors: [
+                {
+                  role: 'author',
+                  name: {
+                    en: 'Rio Tomioka',
+                  },
+                },
+              ],
+              venue: {
+                kind: 'publication',
+                name: {
+                  en: 'Expected Journal',
+                },
               },
-              publication_date: '2024-02-01',
+              dates: {
+                published: '2024-02-01',
+              },
             },
             localMeta: {
               hasEmptyFields: false,
@@ -62,16 +87,17 @@ test('master localMeta.notes does not affect researchmap export inference', () =
       'utf8'
     );
 
-    const publications = loadMasterPublications(masterPath).publications;
+    const sourceMetadata = loadMasterPublications(masterPath);
+    const publications = sourceMetadata.publications;
 
     assert.equal(publications[0].others, '');
     assert.equal(publications[1].others, '');
 
-    const result = generateResearchmapExport(publications, { researchmapUserId: 'R123456789' });
+    const result = generateResearchmapExport(sourceMetadata.records, { researchmapUserId: 'R123456789' });
     const presentationLine = JSON.parse(result.importLines[0]);
     const miscLine = JSON.parse(result.importLines[1]);
 
-    assert.equal(presentationLine.force.promoter.en, 'Expected Conference');
+    assert.equal(presentationLine.force.event.en, 'Expected Conference');
     assert.equal(miscLine.force.volume, undefined);
     assert.equal(miscLine.force.number, undefined);
     assert.equal(miscLine.force.starting_page, undefined);
@@ -143,7 +169,7 @@ test('canonical fields take precedence over stale legacyHints in master publicat
   }
 });
 
-test('legacy researchmapFields preserve promoter and address country in canonical normalization', () => {
+test('canonical venue metadata preserves promoter and address country in master normalization', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'master-to-publications-venue-'));
   const masterPath = path.join(tempDir, 'publication_master.json');
 
@@ -153,24 +179,36 @@ test('legacy researchmapFields preserve promoter and address country in canonica
       JSON.stringify(
         [
           {
-            id: 'pub-2025-legacy-venue-metadata',
-            researchmapFields: {
+            id: 'pub-2025-canonical-venue-metadata',
+            fields: {
               type: 'presentations',
               subtype: 'oral_presentation',
-              presentation_type: 'oral_presentation',
-              presentation_title: {
+              title: {
                 ja: '会場情報付き発表',
               },
-              event: {
-                ja: '研究会',
+              contributors: [
+                {
+                  role: 'presenter',
+                  name: {
+                    ja: 'Rio Tomioka',
+                  },
+                },
+              ],
+              venue: {
+                kind: 'event',
+                name: {
+                  ja: '研究会',
+                },
+                promoter: {
+                  ja: '主催者A',
+                },
+                addressCountry: 'JP',
               },
-              promoter: {
-                ja: '主催者A',
+              dates: {
+                published: '2025-02-03',
+                eventStart: '2025-02-03',
+                eventEnd: '2025-02-03',
               },
-              address_country: 'JP',
-              publication_date: '2025-02-03',
-              from_event_date: '2025-02-03',
-              to_event_date: '2025-02-03',
             },
             localMeta: {
               hasEmptyFields: false,
@@ -185,15 +223,14 @@ test('legacy researchmapFields preserve promoter and address country in canonica
     );
 
     const loaded = loadMasterPublications(masterPath);
-    const rawRecords = JSON.parse(fs.readFileSync(masterPath, 'utf8'));
-    const exportFromLegacyMaster = generateResearchmapExport(rawRecords, {
+    const exportFromMaster = generateResearchmapExport(loaded.records, {
       researchmapUserId: 'R123456789',
     });
 
     assert.equal(loaded.records[0].fields.venue.promoter.ja, '主催者A');
     assert.equal(loaded.records[0].fields.venue.addressCountry, 'JP');
 
-    const exportLine = JSON.parse(exportFromLegacyMaster.importLines[0]);
+    const exportLine = JSON.parse(exportFromMaster.importLines[0]);
     assert.equal(exportLine.force.promoter.ja, '主催者A');
     assert.equal(exportLine.force.address_country, 'JP');
   } finally {
@@ -201,7 +238,7 @@ test('legacy researchmapFields preserve promoter and address country in canonica
   }
 });
 
-test('legacy subtype prefers typed researchmap fields over stale generic subtype', () => {
+test('canonical subtype prefers typed field over stale generic fallback', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'master-to-publications-subtype-'));
   const masterPath = path.join(tempDir, 'publication_master.json');
 
@@ -211,13 +248,26 @@ test('legacy subtype prefers typed researchmap fields over stale generic subtype
       JSON.stringify(
         [
           {
-            id: 'pub-2025-legacy-subtype-priority',
-            researchmapFields: {
+            id: 'pub-2025-canonical-subtype-priority',
+            fields: {
               type: 'published_papers',
-              subtype: 'others',
-              published_paper_type: 'scientific_journal',
-              paper_title: {
+              subtype: 'scientific_journal',
+              title: {
                 en: 'Subtype Priority Paper',
+              },
+              contributors: [
+                {
+                  role: 'author',
+                  name: {
+                    en: 'Rio Tomioka',
+                  },
+                },
+              ],
+              venue: {
+                kind: 'publication',
+                name: {
+                  en: 'Journal A',
+                },
               },
             },
             localMeta: {
@@ -233,15 +283,14 @@ test('legacy subtype prefers typed researchmap fields over stale generic subtype
     );
 
     const loaded = loadMasterPublications(masterPath);
-    const rawRecords = JSON.parse(fs.readFileSync(masterPath, 'utf8'));
-    const exportFromLegacyMaster = generateResearchmapExport(rawRecords, {
+    const exportFromMaster = generateResearchmapExport(loaded.records, {
       researchmapUserId: 'R123456789',
     });
 
     assert.equal(loaded.records[0].fields.subtype, 'scientific_journal');
     assert.equal(loaded.publications[0].type, 'Journal paper：原著論文');
 
-    const exportLine = JSON.parse(exportFromLegacyMaster.importLines[0]);
+    const exportLine = JSON.parse(exportFromMaster.importLines[0]);
     assert.equal(exportLine.force.published_paper_type, 'scientific_journal');
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## 概要

researchmap 連携まわりの legacy compatibility を整理し、`publication_master.json` の canonical `fields` を中心に本線を読み取りやすくしました。

## 変更内容

- researchmap export の master 入力を canonical `fields` 前提に寄せ、`researchmapFields` 互換を本線から外しました
- `masterToPublications` まわりの legacy 変換を縮小し、export tool の説明も本線 / 補助の位置づけに合わせて整理しました
- CSV 由来の移行経路は移行専用であることが読み取れるように整理し、関連テストを canonical `fields` 前提へ更新しました
- `docs/admin/publications-management.md`、`tools/researchmap-private/README.md`、skill docs を、現在の本線と補助の説明に合わせて更新しました

## 影響

- 日常運用の本線が `researchmap export JSONL -> publication_master.json -> publications.json` と `publication_master.json -> researchmap` であることが、コードと docs の両方で追いやすくなります
- `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は補助として維持しています

## 確認

- `npm test -- --runInBand`
  - 143 passed
- `cd tools/researchmap-private && npm test`
  - 55 passed

close: #72
