### PR TITLE
[codex] ホームの氏名表示をプロフィールカード化

### DIFF
--- a/public/markdown/en/home.md
+++ b/public/markdown/en/home.md
@@ -1,7 +1,10 @@
-### Affiliation
-- Assistant Professor, [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/),  
-  [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/) ([Researcher Information](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en))
-- [Bunsen Lab. (Photonics Lab.)](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
+### Rio Tomioka
+
+**Affiliation**: [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/), [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/) ([Bunsen Lab. (Photonics Lab.)](https://www.cis.fukuoka-u.ac.jp/~bunsen/))
+
+**Position**: Assistant Professor ([Researcher Information](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en))
+
+**Degree**: Ph.D. in Computer Science and Systems Engineering
 
 
 ### Contact

--- a/public/markdown/en/home.md
+++ b/public/markdown/en/home.md
@@ -1,6 +1,6 @@
 ### Rio Tomioka
 
-**Affiliation**: [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/), [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/) ([Bunsen Lab. (Photonics Lab.)](https://www.cis.fukuoka-u.ac.jp/~bunsen/))
+**Affiliation**: [Department of Electronics Engineering and Computer Science](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/electronics_computer/), [Faculty of Engineering](https://www.fukuoka-u.ac.jp/english/undergraduate/engineering/), [Fukuoka University](https://www.fukuoka-u.ac.jp/english/), [Bunsen Lab. (Photonics Lab.)](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
 
 **Position**: Assistant Professor ([Researcher Information](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en))
 

--- a/public/markdown/ja/home.md
+++ b/public/markdown/ja/home.md
@@ -1,6 +1,10 @@
-### 所属
-- [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/) 助教（[福岡大学研究者情報](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja)）
-- [文仙研究室（フォトニクス研究室）](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
+### 冨岡 莉生 / TOMIOKA Rio
+
+**所属**: [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/)（[文仙研究室（フォトニクス研究室）](https://www.cis.fukuoka-u.ac.jp/~bunsen/)）
+
+**職位**: 助教（[福岡大学研究者情報](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja)）
+
+**学位**: 博士（情報工学）
 
 
 ### 連絡先

--- a/public/markdown/ja/home.md
+++ b/public/markdown/ja/home.md
@@ -1,6 +1,6 @@
 ### 冨岡 莉生 / TOMIOKA Rio
 
-**所属**: [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/)（[文仙研究室（フォトニクス研究室）](https://www.cis.fukuoka-u.ac.jp/~bunsen/)）
+**所属**: [福岡大学](https://www.fukuoka-u.ac.jp/) [工学部](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/) [電子情報工学科](https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/) [文仙研究室（フォトニクス研究室）](https://www.cis.fukuoka-u.ac.jp/~bunsen/)
 
 **職位**: 助教（[福岡大学研究者情報](https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja)）
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -58,7 +58,7 @@ describe("App component", () => {
     renderApp();
     
     // ヘッダーが存在するか確認（ナビゲーションリンクで確認）
-    const homeLink = screen.getByText(/ホーム/i);
+    const homeLink = screen.getByRole("link", { name: "ホーム" });
     expect(homeLink).toBeInTheDocument();
     
     // メインコンテンツが存在するか確認

--- a/src/__tests__/MarkdownContentPages.test.tsx
+++ b/src/__tests__/MarkdownContentPages.test.tsx
@@ -44,7 +44,15 @@ describe("Markdown content pages", () => {
     renderWithProviders(<Home />, { initialLanguage: "ja" });
 
     expect(
-      await screen.findByText("助教", { exact: false })
+      await screen.findByRole("heading", { name: "冨岡 莉生 / TOMIOKA Rio" })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("助教", { exact: false })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("博士（情報工学）", { exact: false })
     ).toBeInTheDocument();
 
     await waitFor(() => {
@@ -66,13 +74,34 @@ describe("Markdown content pages", () => {
       "href",
       "https://www.fukuoka-u.ac.jp/education/undergraduate/engineering/electronics_computer/"
     );
+
+    expect(
+      screen.getByRole("link", { name: "文仙研究室（フォトニクス研究室）" })
+    ).toHaveAttribute("href", "https://www.cis.fukuoka-u.ac.jp/~bunsen/");
+
+    expect(
+      screen.getByRole("link", { name: "福岡大学研究者情報" })
+    ).toHaveAttribute(
+      "href",
+      "https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=ja"
+    );
   });
 
   test("renders English home content with affiliation links", async () => {
     renderWithProviders(<Home />, { initialLanguage: "en" });
 
     expect(
-      await screen.findByText("Assistant Professor", { exact: false })
+      await screen.findByRole("heading", { name: "Rio Tomioka" })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Assistant Professor", { exact: false })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Ph.D. in Computer Science and Systems Engineering", {
+        exact: false,
+      })
     ).toBeInTheDocument();
 
     await waitFor(() => {
@@ -96,6 +125,17 @@ describe("Markdown content pages", () => {
     expect(
       screen.getByRole("link", { name: "Fukuoka University" })
     ).toHaveAttribute("href", "https://www.fukuoka-u.ac.jp/english/");
+
+    expect(
+      screen.getByRole("link", { name: "Bunsen Lab. (Photonics Lab.)" })
+    ).toHaveAttribute("href", "https://www.cis.fukuoka-u.ac.jp/~bunsen/");
+
+    expect(
+      screen.getByRole("link", { name: "Researcher Information" })
+    ).toHaveAttribute(
+      "href",
+      "https://kenkyusha-db.fukuoka-u.ac.jp/search/detail?systemId=71862344e410b395520e17560c007669&lang=en"
+    );
   });
 
   test("renders Japanese works content with the current and FY2025 sections", async () => {

--- a/src/__tests__/SubHeader.test.tsx
+++ b/src/__tests__/SubHeader.test.tsx
@@ -37,7 +37,7 @@ describe("SubHeader component", () => {
 
     // ホームページの場合のテスト
     test("displays correct Japanese page name for home path", () => {
-      // テスト内容: ルートパス(/)にアクセスした場合、日本語の「冨岡 莉生 (TOMIOKA Rio)」が表示されることを確認
+      // テスト内容: ルートパス(/)にアクセスした場合、日本語の「ホーム」が表示されることを確認
       renderWithProviders(
         <SubHeader />,
         { 
@@ -110,7 +110,7 @@ describe("SubHeader component", () => {
 
     // ホームページの場合のテスト
     test("displays correct English page name for home path", () => {
-      // テスト内容: ルートパス(/)にアクセスした場合、英語の「TOMIOKA Rio」が表示されることを確認
+      // テスト内容: ルートパス(/)にアクセスした場合、英語の「Home」が表示されることを確認
       renderWithProviders(
         <SubHeader />,
         { 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -11,7 +11,7 @@ const en: LocaleMessages = {
   },
   // サブヘッダー
   subheader: {
-    home: 'TOMIOKA Rio',
+    home: 'Home',
     profileCV: 'Profile & Curriculum Vitae (CV)',
     publications: 'Publications',
     works: 'Works',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -11,7 +11,7 @@ const ja: LocaleMessages = {
   },
   // サブヘッダー
   subheader: {
-    home: '冨岡 莉生 (TOMIOKA Rio)',
+    home: 'ホーム',
     profileCV: 'プロフィール & 履歴書 (CV)',
     publications: '出版物',
     works: '仕事',


### PR DESCRIPTION
## 概要
- ホームの帯タイトルを氏名から `ホーム` / `Home` に変更しました。
- ホーム本文の先頭カードを氏名・所属・職位・学位のプロフィール概要に変更しました。
- 既存の所属、研究室、研究者情報リンクをプロフィールカード内に整理しました。

## 確認
- `git diff --check`
- `npm test -- --watchAll=false --runInBand`（150 passed）
- `npm run build`
- ローカル開発サーバーで日本語・英語ホーム表示を確認