### PR TITLE
Google Analyticsタグを追加

### DIFF
--- a/docs/admin/site-configuration.md
+++ b/docs/admin/site-configuration.md
@@ -83,24 +83,18 @@
 
 ### Google Analytics（設定する場合）
 
-このサイトでは、Google Analytics 4（GA4）のトラッキングコードを `public/index.html` の `<head>` に直接追加して設定します。
+このサイトでは、Google Analytics 4（GA4）の測定 ID を Vercel の本番環境変数で管理します。ローカル開発環境やプレビュー環境に計測を混ぜないため、`REACT_APP_GA_ID` は Production のみに設定します。
 
-1. Google Analytics で測定 ID を確認する
+1. Google Analytics で測定 ID を確認する  
    `G-XXXXXXXXXX` 形式の ID を使用します。
-2. `public/index.html` の `<head>` に Google tag を追加する
-3. デプロイ後に Google Analytics のリアルタイム画面で計測を確認する
+2. Vercel の Project Settings で `REACT_APP_GA_ID` を Production のみに追加する
+3. 本番デプロイ後に Google Analytics のリアルタイム画面で計測を確認する
 
-```html
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-XXXXXXXXXX');
-</script>
+```env
+REACT_APP_GA_ID=G-XXXXXXXXXX
 ```
+
+`REACT_APP_GA_ID` が設定されていないビルドでは、Google Analytics のタグは読み込まれません。
 
 ### ソーシャルメディア
 
@@ -160,7 +154,7 @@ REACT_APP_API_URL=https://api.example.com
 REACT_APP_GA_ID=G-XXXXXXXXXX
 ```
 
-現在の Google Analytics 設定は `public/index.html` への直接埋め込みで運用しています。環境ごとに測定 ID を切り替えたい場合のみ、`REACT_APP_GA_ID` のような環境変数管理を検討してください。
+現在の Google Analytics 設定は、Vercel の Production 環境に `REACT_APP_GA_ID` を設定して運用します。Preview と Development には設定しないことで、検証アクセスが本番分析に混ざらないようにします。
 
 **注意**: `.env`ファイルはGitにコミットしないでください。
 

--- a/docs/admin/site-configuration.md
+++ b/docs/admin/site-configuration.md
@@ -83,8 +83,24 @@
 
 ### Google Analytics（設定する場合）
 
-1. `public/index.html`にトラッキングコードを追加
-2. 環境変数でトラッキングIDを管理（推奨）
+このサイトでは、Google Analytics 4（GA4）のトラッキングコードを `public/index.html` の `<head>` に直接追加して設定します。
+
+1. Google Analytics で測定 ID を確認する
+   `G-XXXXXXXXXX` 形式の ID を使用します。
+2. `public/index.html` の `<head>` に Google tag を追加する
+3. デプロイ後に Google Analytics のリアルタイム画面で計測を確認する
+
+```html
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+```
 
 ### ソーシャルメディア
 
@@ -141,8 +157,10 @@ tar -xzf backup_20240101.tar.gz
 ```env
 # 例
 REACT_APP_API_URL=https://api.example.com
-REACT_APP_GA_ID=UA-XXXXXXXX-X
+REACT_APP_GA_ID=G-XXXXXXXXXX
 ```
+
+現在の Google Analytics 設定は `public/index.html` への直接埋め込みで運用しています。環境ごとに測定 ID を切り替えたい場合のみ、`REACT_APP_GA_ID` のような環境変数管理を検討してください。
 
 **注意**: `.env`ファイルはGitにコミットしないでください。
 

--- a/public/index.html
+++ b/public/index.html
@@ -24,16 +24,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1KNFWH1QEM"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-1KNFWH1QEM');
-    </script>
-
     <!-- google font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,16 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1KNFWH1QEM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-1KNFWH1QEM');
+    </script>
+
     <!-- google font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/__tests__/googleAnalytics.test.ts
+++ b/src/__tests__/googleAnalytics.test.ts
@@ -1,0 +1,43 @@
+import { initializeGoogleAnalytics } from "../utils/googleAnalytics";
+
+describe("initializeGoogleAnalytics", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    delete window.dataLayer;
+    delete window.gtag;
+  });
+
+  test("does not add the Google Analytics script without a measurement ID", () => {
+    // Arrange & Act
+    initializeGoogleAnalytics("");
+
+    // Assert
+    expect(document.querySelector("script[src*='googletagmanager']")).toBeNull();
+    expect(window.dataLayer).toBeUndefined();
+    expect(window.gtag).toBeUndefined();
+  });
+
+  test("adds and configures the Google Analytics script with a measurement ID", () => {
+    // Arrange & Act
+    initializeGoogleAnalytics("G-TEST12345");
+
+    // Assert
+    expect(document.getElementById("google-analytics-gtag")).toHaveAttribute(
+      "src",
+      "https://www.googletagmanager.com/gtag/js?id=G-TEST12345"
+    );
+    expect(window.dataLayer).toEqual([
+      ["js", expect.any(Date)],
+      ["config", "G-TEST12345"],
+    ]);
+  });
+
+  test("does not add duplicate scripts when initialized more than once", () => {
+    // Arrange & Act
+    initializeGoogleAnalytics("G-TEST12345");
+    initializeGoogleAnalytics("G-TEST12345");
+
+    // Assert
+    expect(document.querySelectorAll("script[src*='googletagmanager']")).toHaveLength(1);
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,12 @@ import App from "./App";
 import "./styles/variables.css";
 import "./styles/styles.css";
 import { mantineCache } from "./mantineEmotionCache";
+import { initializeGoogleAnalytics } from "./utils/googleAnalytics";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Failed to find the root element");
+
+initializeGoogleAnalytics();
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -1,0 +1,40 @@
+type GtagArguments = [command: string, ...args: unknown[]];
+
+declare global {
+  interface Window {
+    dataLayer?: GtagArguments[];
+    gtag?: (...args: GtagArguments) => void;
+  }
+}
+
+const GOOGLE_ANALYTICS_SCRIPT_ID = "google-analytics-gtag";
+
+export function initializeGoogleAnalytics(
+  measurementId = process.env.REACT_APP_GA_ID
+): void {
+  const trimmedMeasurementId = measurementId?.trim();
+
+  if (!trimmedMeasurementId || typeof window === "undefined") {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag =
+    window.gtag ||
+    ((...args: GtagArguments) => {
+      window.dataLayer?.push(args);
+    });
+
+  if (!document.getElementById(GOOGLE_ANALYTICS_SCRIPT_ID)) {
+    const script = document.createElement("script");
+    script.id = GOOGLE_ANALYTICS_SCRIPT_ID;
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+      trimmedMeasurementId
+    )}`;
+    document.head.appendChild(script);
+  }
+
+  window.gtag("js", new Date());
+  window.gtag("config", trimmedMeasurementId);
+}


### PR DESCRIPTION
## 概要
- `public/index.html` に Google Analytics 4 のタグを直接埋め込み
- 管理ドキュメントを現行運用に合わせて更新
- 古い `UA-` 形式の例を `G-` 形式へ修正

## 確認
- `npm run build`

## 補足
- 測定 ID は `G-1KNFWH1QEM` を使用しています。