### PR TITLE
OpenSSL legacy provider 設定を削除する

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -105,7 +105,9 @@ npm install
 
 ### OpenSSLエラーが発生する場合
 
-package.jsonのスクリプトに`NODE_OPTIONS=--openssl-legacy-provider`が設定されています。
+現在の開発環境では `NODE_OPTIONS=--openssl-legacy-provider` を付けずに `npm start` と `npm run build` を実行します。
+
+OpenSSL関連のエラーが再発した場合は、まず Node.js と `react-scripts` のバージョン、依存関係の更新状況を確認してください。古い Node.js / Webpack 系の組み合わせでのみ legacy provider が必要になる場合があります。
 
 ### テストが失敗する場合
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "yocto-queue": "^1.2.0"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false --runInBand",
     "test:watch": "react-scripts test --runInBand",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## 対応内容
- `package.json` の `start` / `build` から `NODE_OPTIONS=--openssl-legacy-provider` を削除しました。
- `docs/technical/README.md` の OpenSSL エラー説明を、現行環境では通常不要で、再発時に Node.js / react-scripts / 依存関係を確認する内容へ更新しました。

close: #90

## 確認
- `npm run build`
- `npm test`
- `PORT=3090 BROWSER=none npm start`

## 補足
- ローカル環境は Node.js `v25.2.1` / npm `11.6.2` / react-scripts `5.0.1` です。
- Vercel preview / production build は PR 作成後の checks とマージ後 deployment で確認します。