### PR TITLE
出版物運用 docs の legacy 記述を整理

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -7,6 +7,7 @@
 - [多言語コンテンツ管理](./multilingual-content-management.md) - サイトの多言語対応とコンテンツ更新方法
 - [Markdownコンテンツ管理](./markdown-content.md) - 各ページのコンテンツ編集方法
 - [出版物データ管理](./publications-management.md) - master data・researchmap 連携・生成物再生成を含む出版物管理
+- [抄録候補ソース](./publication-abstract-sources.md) - `publication_master.json` の `fields.description` を確認・補完するときの補助メモ
 - [デプロイメント手順](./deployment-guide.md) - サイトの公開と更新手順
 - [サイト設定ガイド](./site-configuration.md) - サイトの基本設定と構成
 

--- a/docs/admin/publication-abstract-sources.md
+++ b/docs/admin/publication-abstract-sources.md
@@ -1,6 +1,8 @@
-# abstract 候補ソース
+# 抄録候補ソース
 
-2026年3月15日時点で、web 検索で abstract 原文を確認できた publication データのソースを整理します。
+2026年3月15日時点で、Web 検索で abstract 原文を確認できた publication データのソースを整理します。
+
+このページは `src/data/publication_master.json` の `fields.description` を確認・補完するときの補助メモです。出版物データの正本と更新手順は [出版物データ管理](./publications-management.md) を参照してください。
 
 - `Numerical simulations on optoelectronic deep neural network hardware based on self-referential holography`
   - Source: [10.1007/s10043-023-00810-2](https://doi.org/10.1007/s10043-023-00810-2)
@@ -47,6 +49,6 @@
 - `Numerical Simulations of Parallel Image Recognition with Self-Referential Holographic Deep Neural Network`
   - Source: [IWH 2025 book program PDF](https://www.iwh2025.org/uploads/1/5/2/6/152641567/_ooo_1027_book_program.pdf)
 
-現在の CSV には、上記で原文を確認できた項目のみを反映しています。ITE の一部ページは `Not available yet` だったため未反映です。後で Notion 側の正本を更新する際の確認用メモとして使ってください。
+上記のうち原文を確認できた項目だけを `publication_master.json` へ反映します。ITE の一部ページは `Not available yet` だったため、後日 `fields.description` を補完するときに再確認します。
 
-なお、著作権配慮のため、PDF 等から抽出した長文の verbatim abstract は CSV から空欄に戻しています。
+著作権配慮のため、PDF 等から抽出した長文の verbatim abstract はそのまま転載せず、公開ページに載せる必要がある場合は短い要約または公開元へのリンクで扱います。

--- a/docs/admin/publications-management.md
+++ b/docs/admin/publications-management.md
@@ -76,7 +76,7 @@ flowchart LR
 - 通常運用の本線は `researchmap export JSONL -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - 逆向きの `publication_master.json -> researchmap` は、researchmap へ安全に再投入したいときだけ使う補助ツールです
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 側の情報を壊しにくくし、生成結果の由来や整合を確認するための補助です
-- 旧 `researchmapFields` 形式の master は受け付けません
+- 過去の `researchmapFields` 形式は移行済みの legacy schema です。現行ツールの入力は canonical `fields` を持つ `publication_master.json` だけに統一します
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモで、`publication_master.json` 自体は public 側の tracked canonical data として扱います
 
 ## master data の構造

--- a/tools/researchmap-private/README.md
+++ b/tools/researchmap-private/README.md
@@ -7,7 +7,7 @@
 - 通常運用の本線は `researchmap -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - このディレクトリは、必要なときだけ `publication_master.json` から researchmap へ安全に戻すための補助ツールをまとめています
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 情報を壊しにくくし、生成結果の由来や整合を確認しやすくするための補助機能です
-- 旧 `researchmapFields` 形式の master は受け付けません。`publication_master.json` は canonical `fields` を持つ record を正本として扱います
+- `publication_master.json` は canonical `fields` を持つ record を正本として扱い、このツールも canonical `fields` から researchmap payload を生成します
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモで、`publication_master.json` 自体は public 側の tracked canonical data として扱います
 
 ## 使い方

--- a/tools/researchmap-private/skills/researchmap-bulk-import/SKILL.md
+++ b/tools/researchmap-private/skills/researchmap-bulk-import/SKILL.md
@@ -12,7 +12,7 @@ description: Convert publication_master.json into researchmap bulk-import JSONL,
 - 通常運用の本線は `researchmap -> publication_master.json -> publications.json` で、公開側の tracked data 更新はここで完結します
 - この skill は、必要なときだけ `publication_master.json` から researchmap へ安全に戻すための補助です
 - `researchmapMerge` / `researchmapReversibleExport` / `researchmapConsistency` は、既存 researchmap 側の情報を壊しにくくし、生成結果の由来や整合を追えるようにする補助として扱います
-- 旧 `researchmapFields` 形式の master は受け付けません。canonical `fields` を持つ `publication_master.json` を前提にします
+- canonical `fields` を持つ `publication_master.json` を入力にし、researchmap payload はそこから直接組み立てます
 - local-only に残すのは `tmp/researchmap/**`、review / quarantine / archive の生成物、将来のローカル補助メモです
 
 ## 手順


### PR DESCRIPTION
## 概要

close: #76

出版物運用 docs に残っていた stale な CSV / Notion 正本前提の説明を整理しました。

## 変更内容

- `publication-abstract-sources.md` を `publication_master.json` の `fields.description` を確認・補完するときの補助メモとして再位置づけ
- `docs/admin/README.md` に抄録候補ソースへの導線を追加
- `researchmapFields` の説明を、移行済み legacy schema として `publications-management.md` に集約
- researchmap 補助ツール側 README / skill docs は canonical `fields` 入力の説明に整理

## 確認

- `git diff --check`
- `rg -n "publication_data\.csv|Notion 側の正本|CSV" docs tools/researchmap-private README.md AGENTS.md`
- `rg -n "researchmapFields|旧 researchmapFields" docs tools/researchmap-private README.md AGENTS.md`

## 残課題

- なし
