### PR TITLE
PublicationItem の表示値生成を分離する

### DIFF
--- a/src/__tests__/PublicationItem.test.tsx
+++ b/src/__tests__/PublicationItem.test.tsx
@@ -17,6 +17,7 @@ import '@testing-library/jest-dom';
 import PublicationItem from '../components/publications/PublicationItem';
 import { renderWithProviders } from '../test-utils/test-utils';
 import { createPublication } from '../test-utils/factories/publicationFactory'; // ファクトリ関数をインポート
+import { buildPublicationItemViewModel } from '../utils/publicationItemViewModel';
 
 // ファクトリ関数を使用してテストデータを生成
 const mockPublication = createPublication({
@@ -44,6 +45,79 @@ const mockPublicationWithArrays = createPublication({
   id: 2,
   authorship: ["corresponding", "lead"], // 配列で上書き
 }, 1); // index 1
+
+describe('buildPublicationItemViewModel', () => {
+  test('builds English display values for PublicationItem', () => {
+    const viewModel = buildPublicationItemViewModel(mockPublicationWithArrays, 'en');
+
+    expect(viewModel).toMatchObject({
+      title: mockPublication.name,
+      tags: [
+        '2021',
+        'Corresponding Author',
+        'Lead Author',
+        'Published Papers / International Conference Proceedings',
+        'Peer Reviewed',
+      ],
+      journal: 'ISOM21',
+      dateLocation: {
+        dateLabel: 'Date: ',
+        dateValue: '2021-10-03 → 2021-10-06',
+        locationLabel: 'Location: ',
+        location: 'online',
+      },
+      doi: {
+        href: 'https://doi.org/10.1234/example',
+        label: '10.1234/example',
+      },
+      webLink: {
+        href: 'https://example.com',
+        label: 'https://example.com',
+      },
+      others: 'Best Paper Award',
+    });
+  });
+
+  test('builds Japanese display values through the same view model', () => {
+    const viewModel = buildPublicationItemViewModel(mockPublicationWithArrays, 'ja');
+
+    expect(viewModel.title).toBe(mockPublication.japanese);
+    expect(viewModel.tags).toEqual([
+      '2021',
+      '責任著者',
+      '筆頭著者',
+      '研究論文 / 国際会議プロシーディングス',
+      '査読あり',
+    ]);
+    expect(viewModel.dateLocation).toMatchObject({
+      dateLabel: '日付: ',
+      dateValue: '2021-10-03 → 2021-10-06',
+      locationLabel: '場所: ',
+      location: 'online',
+    });
+  });
+
+  test('normalizes DOI URLs and trims abstract text without changing link labels', () => {
+    const publication = createPublication({
+      ...mockPublication,
+      id: 8,
+      abstract: '  Abstract text  ',
+      doi: 'https://dx.doi.org/10.9999/example',
+    }, 7);
+
+    const viewModel = buildPublicationItemViewModel(publication, 'en');
+
+    expect(viewModel.doi).toEqual({
+      href: 'https://doi.org/10.9999/example',
+      label: '10.9999/example',
+    });
+    expect(viewModel.webLink).toEqual({
+      href: 'https://example.com',
+      label: 'https://example.com',
+    });
+    expect(viewModel.abstractText).toBe('Abstract text');
+  });
+});
 
 describe('PublicationItem Component', () => {
   // 基本的なレンダリングテスト

--- a/src/components/publications/PublicationItem.tsx
+++ b/src/components/publications/PublicationItem.tsx
@@ -3,11 +3,7 @@ import { createStyles } from "@mantine/emotion";
 import { MantineTheme } from "@mantine/core";
 import { Language, Publication } from "../../types";
 import locales from "../../locales";
-import {
-  getPublicationAuthorshipLabel,
-  getPublicationReviewLabel,
-  getPublicationTypeLabel,
-} from "../../utils/publicationLabels";
+import { buildPublicationItemViewModel } from "../../utils/publicationItemViewModel";
 
 // PublicationItemPropsインターフェースを追加
 interface PublicationItemProps {
@@ -170,9 +166,7 @@ function PublicationItem({ publication, language, index = 1 }: PublicationItemPr
   const { classes, cx } = useStyles();
   const [isAbstractOpen, setIsAbstractOpen] = useState(false);
   const messages = locales[language] ?? locales.en;
-  const abstractText = publication.abstract?.trim();
-  const normalizedDoi = publication.doi.replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, "");
-  const doiHref = normalizedDoi ? `https://doi.org/${normalizedDoi}` : "";
+  const viewModel = buildPublicationItemViewModel(publication, language);
   
   return (
     <li className={classes.item} data-testid="publication-item">
@@ -182,55 +176,20 @@ function PublicationItem({ publication, language, index = 1 }: PublicationItemPr
 
       {/* 一行目: タイトル */}
       <div className={classes.title} data-testid="publication-title">
-        {language === 'ja' && publication.japanese ? publication.japanese : publication.name}
+        {viewModel.title}
       </div>
       
       {/* 二行目: タグ（Year、Authorship、type、Review） */}
       <div className={classes.tagsContainer} data-testid="tags-container">
-        {publication.year && (
-          <span className={classes.tag} data-testid="tag">
-            {publication.year}
+        {viewModel.tags.map((tag, index) => (
+          <span key={`${tag}-${index}`} className={classes.tag} data-testid="tag">
+            {tag}
           </span>
-        )}
-        
-        {publication.authorship && (
-          <>
-            {Array.isArray(publication.authorship) ? (
-              // 配列の場合は各要素を個別のタグとして表示
-              publication.authorship.map((role, index) => (
-                <span
-                  key={`role-${index}`}
-                  className={classes.tag}
-                  data-testid="tag"
-                >
-                  {getPublicationAuthorshipLabel(role, language)}
-                </span>
-              ))
-            ) : (
-              // 文字列の場合は単一のタグとして表示
-              <span className={classes.tag} data-testid="tag">
-                {getPublicationAuthorshipLabel(publication.authorship, language)}
-              </span>
-            )}
-          </>
-        )}
-        
-        {publication.type && (
-          <span className={classes.tag} data-testid="tag">
-            {getPublicationTypeLabel(publication.type, language)}
-          </span>
-        )}
-        
-        {publication.review && (
-          <span className={classes.tag} data-testid="tag">
-            {getPublicationReviewLabel(publication.review, language)}
-          </span>
-        )}
-        
+        ))}
       </div>
       
       {/* 三行目: ジャーナル名 */}
-      <div className={classes.journal}>{publication.journalConference || publication.journal}</div>
+      <div className={classes.journal}>{viewModel.journal}</div>
       
       {/* 四行目: 開始日、終了日、場所 */}
       {(publication.startDate || publication.site) && (
@@ -238,11 +197,8 @@ function PublicationItem({ publication, language, index = 1 }: PublicationItemPr
           {/* 開始日と終了日が同じ場合は開始日のみ表示 */}
           {publication.startDate && (
             <>
-              {language === 'ja' ? '日付: ' : 'Date: '}
-              {publication.startDate === publication.endDate ?
-                publication.startDate :
-                `${publication.startDate} → ${publication.endDate}`
-              }
+              {viewModel.dateLocation.dateLabel}
+              {viewModel.dateLocation.dateValue}
             </>
           )}
           
@@ -250,37 +206,37 @@ function PublicationItem({ publication, language, index = 1 }: PublicationItemPr
           {publication.site && (
             <>
               {publication.startDate && <span className={classes.separator}>|</span>}
-              {language === 'ja' ? '場所: ' : 'Location: '}
-              {publication.site}
+              {viewModel.dateLocation.locationLabel}
+              {viewModel.dateLocation.location}
             </>
           )}
         </div>
       )}
       
       {/* 五行目以降: DOI、URL、Others */}
-      {normalizedDoi && (
+      {viewModel.doi && (
         <div className={classes.link}>
-          DOI: <a href={doiHref} target="_blank" rel="noopener noreferrer">
-            {normalizedDoi}
+          DOI: <a href={viewModel.doi.href} target="_blank" rel="noopener noreferrer">
+            {viewModel.doi.label}
           </a>
         </div>
       )}
       
-      {publication.webLink && (
+      {viewModel.webLink && (
         <div className={classes.link}>
-          <a href={publication.webLink} target="_blank" rel="noopener noreferrer">
-            {publication.webLink}
+          <a href={viewModel.webLink.href} target="_blank" rel="noopener noreferrer">
+            {viewModel.webLink.label}
           </a>
         </div>
       )}
       
-      {publication.others && (
+      {viewModel.others && (
         <div className={classes.others}>
-          {publication.others}
+          {viewModel.others}
         </div>
       )}
 
-      {abstractText && (
+      {viewModel.abstractText && (
         <>
           <button
             type="button"
@@ -299,7 +255,7 @@ function PublicationItem({ publication, language, index = 1 }: PublicationItemPr
               data-testid="abstract-content"
               aria-label={messages.publications.abstractLabel}
             >
-              {abstractText}
+              {viewModel.abstractText}
             </div>
           )}
         </>

--- a/src/utils/publicationItemViewModel.ts
+++ b/src/utils/publicationItemViewModel.ts
@@ -1,0 +1,102 @@
+import { Language, Publication } from "../types";
+import {
+  getPublicationAuthorshipLabel,
+  getPublicationReviewLabel,
+  getPublicationTypeLabel,
+} from "./publicationLabels";
+
+interface PublicationItemLinkViewModel {
+  href: string;
+  label: string;
+}
+
+export interface PublicationItemViewModel {
+  title: string;
+  tags: string[];
+  journal: string;
+  dateLocation: {
+    dateLabel: string;
+    dateValue: string;
+    locationLabel: string;
+    location: string;
+  };
+  doi: PublicationItemLinkViewModel | null;
+  webLink: PublicationItemLinkViewModel | null;
+  others: string;
+  abstractText: string;
+}
+
+export function buildPublicationItemViewModel(
+  publication: Publication,
+  language: Language
+): PublicationItemViewModel {
+  const normalizedDoi = normalizeDoi(publication.doi);
+
+  return {
+    title: language === "ja" && publication.japanese ? publication.japanese : publication.name,
+    tags: buildPublicationTags(publication, language),
+    journal: publication.journalConference || publication.journal || "",
+    dateLocation: {
+      dateLabel: language === "ja" ? "日付: " : "Date: ",
+      dateValue: buildDateValue(publication),
+      locationLabel: language === "ja" ? "場所: " : "Location: ",
+      location: publication.site,
+    },
+    doi: normalizedDoi
+      ? {
+          href: `https://doi.org/${normalizedDoi}`,
+          label: normalizedDoi,
+        }
+      : null,
+    webLink: publication.webLink
+      ? {
+          href: publication.webLink,
+          label: publication.webLink,
+        }
+      : null,
+    others: publication.others,
+    abstractText: publication.abstract?.trim() || "",
+  };
+}
+
+function buildPublicationTags(publication: Publication, language: Language): string[] {
+  const tags: string[] = [];
+
+  if (publication.year) {
+    tags.push(String(publication.year));
+  }
+
+  const authorshipRoles = Array.isArray(publication.authorship)
+    ? publication.authorship
+    : publication.authorship
+      ? [publication.authorship]
+      : [];
+
+  authorshipRoles.forEach((role) => {
+    tags.push(getPublicationAuthorshipLabel(role, language));
+  });
+
+  if (publication.type) {
+    tags.push(getPublicationTypeLabel(publication.type, language));
+  }
+
+  if (publication.review) {
+    tags.push(getPublicationReviewLabel(publication.review, language));
+  }
+
+  return tags;
+}
+
+function buildDateValue(publication: Publication): string {
+  if (!publication.startDate) {
+    return "";
+  }
+
+  return publication.startDate === publication.endDate
+    ? publication.startDate
+    : `${publication.startDate} → ${publication.endDate}`;
+}
+
+function normalizeDoi(doi: string): string {
+  return doi.replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, "");
+}


### PR DESCRIPTION
## 対応内容

- `PublicationItem` 内で組み立てていた DOI href、表示タイトル、タグ、日付・場所、リンク、abstract 表示値を `buildPublicationItemViewModel` に分離しました。
- `PublicationItem` は既存の Mantine 構造や表示条件を維持し、view model を描画する形に整理しました。
- 日本語・英語双方の表示値、DOI 正規化、link label、abstract trim を確認するテストを追加しました。

## 確認結果

- `npm test -- --runTestsByPath src/__tests__/PublicationItem.test.tsx` : PASS（12 tests）
- `git diff --check` : PASS
- 実装差分に対する別視点の確認で、Issue の受け入れ条件と趣旨に沿っていることを確認済みです。

## 注意点

日付・場所ブロックの表示有無と区切り条件は、今後さらに view model 側へ寄せられる余地があります。今回の受け入れ条件を妨げる残課題ではありません。

close: #99