### PR TITLE
markdownLoader の path 生成とログ出力を整理する

### DIFF
--- a/src/__tests__/markdownLoader.test.ts
+++ b/src/__tests__/markdownLoader.test.ts
@@ -12,15 +12,43 @@
  * 4. ネットワークエラーなどのfetchエラーのハンドリング
  */
 
-import { loadMarkdown } from "../utils/markdownLoader";
+import { buildMarkdownPath, loadMarkdown } from "../utils/markdownLoader";
 
 // fetchのモック
 global.fetch = jest.fn();
 
 describe("markdownLoader", () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     // モックをリセット
     fetch.mockClear();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    jest.restoreAllMocks();
+  });
+
+  test("builds markdown path with default language (ja)", () => {
+    expect(buildMarkdownPath("/markdown/test.md")).toBe("/markdown/ja/test.md");
+  });
+
+  test("builds markdown path with specified language", () => {
+    expect(buildMarkdownPath("/markdown/test.md", "en")).toBe("/markdown/en/test.md");
+  });
+
+  test("builds markdown path for subdirectories", () => {
+    expect(buildMarkdownPath("/markdown/works/test.md", "ja")).toBe(
+      "/markdown/ja/works/test.md"
+    );
+    expect(buildMarkdownPath("/markdown/works/2025/test.md", "en")).toBe(
+      "/markdown/en/works/2025/test.md"
+    );
   });
 
   test("loads markdown file with default language (ja)", async () => {

--- a/src/__tests__/markdownLoader.test.ts
+++ b/src/__tests__/markdownLoader.test.ts
@@ -147,6 +147,28 @@ describe("markdownLoader", () => {
     consoleErrorSpy.mockClear();
   });
 
+  test("logs status 0 diagnostics outside the test environment", async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 0
+      })
+    );
+
+    const content = await loadMarkdown("/markdown/test.md", "en");
+
+    expect(content).toBe("# Error loading content");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error loading markdown:",
+      "/markdown/en/test.md: Failed to load markdown file: /markdown/en/test.md (status: 0)"
+    );
+
+    process.env.NODE_ENV = originalNodeEnv;
+    consoleErrorSpy.mockClear();
+  });
+
   // サブディレクトリを含むパスのテスト
   test("loads markdown file from subdirectory with language", async () => {
     // テスト内容: サブディレクトリを含むパスで言語固有のMarkdownファイルを読み込むことを確認

--- a/src/__tests__/markdownLoader.test.ts
+++ b/src/__tests__/markdownLoader.test.ts
@@ -128,6 +128,25 @@ describe("markdownLoader", () => {
     expect(content).toBe("# Error loading content");
   });
 
+  test("logs the generated path with fetch errors outside the test environment", async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    fetch.mockImplementation(() =>
+      Promise.reject(new Error("Network error"))
+    );
+
+    const content = await loadMarkdown("/markdown/test.md", "en");
+
+    expect(content).toBe("# Error loading content");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error loading markdown:",
+      "/markdown/en/test.md: Network error"
+    );
+
+    process.env.NODE_ENV = originalNodeEnv;
+    consoleErrorSpy.mockClear();
+  });
+
   // サブディレクトリを含むパスのテスト
   test("loads markdown file from subdirectory with language", async () => {
     // テスト内容: サブディレクトリを含むパスで言語固有のMarkdownファイルを読み込むことを確認

--- a/src/utils/markdownLoader.ts
+++ b/src/utils/markdownLoader.ts
@@ -2,47 +2,53 @@
  * Markdownファイルを読み込むためのユーティリティ関数
  */
 
+const ERROR_MARKDOWN_CONTENT = '# Error loading content';
+
+export const buildMarkdownPath = (filePath: string, language: string = 'ja'): string => {
+  const pathParts = filePath.split('/');
+  const markdownIndex = pathParts.indexOf('markdown');
+  const fileName = pathParts[pathParts.length - 1];
+  const directoryParts =
+    markdownIndex === -1 ? [] : pathParts.slice(markdownIndex + 1, pathParts.length - 1);
+  const subPath = directoryParts.length > 0 ? `${directoryParts.join('/')}/` : '';
+
+  return `/markdown/${language}/${subPath}${fileName}`;
+};
+
+const shouldLogMarkdownError = (): boolean => process.env.NODE_ENV !== 'test';
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+const logMarkdownLoadError = (error: unknown): void => {
+  if (!shouldLogMarkdownError()) {
+    return;
+  }
+
+  console.error('Error loading markdown:', getErrorMessage(error));
+};
+
 // Markdownファイルを読み込む関数
 export const loadMarkdown = async (filePath: string, language: string = 'ja'): Promise<string> => {
+  const langPath = buildMarkdownPath(filePath, language);
+
   try {
-    // 言語に応じたパスを生成
-    // 例: /markdown/home.md → /markdown/ja/home.md または /markdown/en/home.md
-    // 例: /markdown/works/computer-system-2025.md → /markdown/ja/works/computer-system-2025.md
-    const pathParts = filePath.split('/');
-    
-    // /markdownの後のパスを取得
-    let subPath = '';
-    let markdownIndex = -1;
-    
-    // /markdownの位置を探す
-    for (let i = 0; i < pathParts.length; i++) {
-      if (pathParts[i] === 'markdown') {
-        markdownIndex = i;
-        break;
-      }
-    }
-    
-    // /markdownの後のパスを結合（ファイル名を除く）
-    if (markdownIndex !== -1 && pathParts.length > markdownIndex + 2) {
-      // /markdown/の後に少なくとも2つの要素がある場合（サブディレクトリとファイル名）
-      subPath = pathParts.slice(markdownIndex + 1, pathParts.length - 1).join('/') + '/';
-    }
-    
-    const fileName = pathParts[pathParts.length - 1];
-    const langPath = `/markdown/${language}/${subPath}${fileName}`;
-    
-    console.log('Loading markdown from:', langPath);
-    
     const response: Response = await fetch(langPath);
 
     if (!response.ok) {
-      throw new Error(`Failed to load markdown file: ${langPath}`);
+      const statusInfo = response.status ? ` (status: ${response.status})` : '';
+      throw new Error(`Failed to load markdown file: ${langPath}${statusInfo}`);
     }
     
     const text: string = await response.text();
     return text;
-  } catch (error: any) {
-    console.error('Error loading markdown:', error.message);
-    return '# Error loading content';
+  } catch (error: unknown) {
+    logMarkdownLoadError(error);
+    return ERROR_MARKDOWN_CONTENT;
   }
 };

--- a/src/utils/markdownLoader.ts
+++ b/src/utils/markdownLoader.ts
@@ -25,12 +25,12 @@ const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
-const logMarkdownLoadError = (error: unknown): void => {
+const logMarkdownLoadError = (error: unknown, path: string): void => {
   if (!shouldLogMarkdownError()) {
     return;
   }
 
-  console.error('Error loading markdown:', getErrorMessage(error));
+  console.error('Error loading markdown:', `${path}: ${getErrorMessage(error)}`);
 };
 
 // Markdownファイルを読み込む関数
@@ -44,11 +44,11 @@ export const loadMarkdown = async (filePath: string, language: string = 'ja'): P
       const statusInfo = response.status ? ` (status: ${response.status})` : '';
       throw new Error(`Failed to load markdown file: ${langPath}${statusInfo}`);
     }
-    
+
     const text: string = await response.text();
     return text;
   } catch (error: unknown) {
-    logMarkdownLoadError(error);
+    logMarkdownLoadError(error, langPath);
     return ERROR_MARKDOWN_CONTENT;
   }
 };

--- a/src/utils/markdownLoader.ts
+++ b/src/utils/markdownLoader.ts
@@ -41,7 +41,7 @@ export const loadMarkdown = async (filePath: string, language: string = 'ja'): P
     const response: Response = await fetch(langPath);
 
     if (!response.ok) {
-      const statusInfo = response.status ? ` (status: ${response.status})` : '';
+      const statusInfo = typeof response.status === 'number' ? ` (status: ${response.status})` : '';
       throw new Error(`Failed to load markdown file: ${langPath}${statusInfo}`);
     }
 


### PR DESCRIPTION
## 対応内容

- Markdown path 生成を `buildMarkdownPath` helper に分離しました。
- 既存の `/markdown/{language}/...` 解決仕様を維持しました。
- 成功時の常時 `console.log` を削除し、test 環境では `console.error` も抑制するようにしました。
- エラー時の診断情報として、path と取得できる場合の HTTP status を含めるようにしました。
- fetch 自体が失敗した場合も、非 test 環境のエラーログに生成済み path と元エラーを含めるようにしました。
- `status: 0` の non-ok response でも HTTP status を診断情報へ残すようにしました。

## 確認結果

- `npm test -- --runTestsByPath src/__tests__/markdownLoader.test.ts --watchAll=false --runInBand` : PASS（12 tests）
- `npm test -- --watchAll=false --runInBand` : PASS（22 suites / 179 tests）
- `git diff --check main...HEAD` : PASS
- 通常のテスト出力で `Loading markdown from...` / `Error loading markdown...` の console ノイズが出ないことを確認しました。
- 非 test 環境で fetch が失敗した場合も、生成済み path を含む診断情報が出ることをテストで確認しました。
- `status: 0` の non-ok response でも診断情報に status が残ることをテストで確認しました。
- 実装差分に対する別視点の確認で、Issue の受け入れ条件と趣旨に沿っていることを確認済みです。

## 注意点

- 全体テストでは既存の React Router / ReactMarkdown 警告が出ますが、テストは全件通過しており、今回差分由来の失敗はありません。

close: #100